### PR TITLE
[FEAT/global] CustomException 구현

### DIFF
--- a/src/main/java/com/bugzero/rarego/global/exception/CustomException.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.bugzero.rarego.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+	private final ErrorType errorType;
+
+	public CustomException(ErrorType errorType) {
+		super(errorType.getMessage());
+		this.errorType = errorType;
+	}
+
+	// 상세 메시지 추가 사용 (상황에 따른 가변적인 메시지)
+	public CustomException(ErrorType errorType, String detailMessage) {
+		super(detailMessage);
+		this.errorType = errorType;
+	}
+}

--- a/src/main/java/com/bugzero/rarego/global/exception/ErrorType.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/ErrorType.java
@@ -1,0 +1,14 @@
+package com.bugzero.rarego.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorType {
+	INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.")
+	;
+
+	private final Integer httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/bugzero/rarego/global/exception/ExceptionResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/ExceptionResponseDto.java
@@ -1,0 +1,8 @@
+package com.bugzero.rarego.global.exception;
+
+public record ExceptionResponseDto(Integer status, String message) {
+
+	public static ExceptionResponseDto to(Integer status, String message) {
+		return new ExceptionResponseDto(status, message);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.bugzero.rarego.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ExceptionResponseDto> handleCustomException(CustomException e) {
+		log.error("CustomException 발생: {}", e.getMessage());
+		return ResponseEntity.status(e.getErrorType().getHttpStatus())
+			.body(ExceptionResponseDto.to(e.getErrorType().getHttpStatus(), e.getErrorType().getMessage()));
+	}
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #10

## 🚀 작업 내용
- CustomException 생성
  - RunTimeException 발생 시 약속된 에러메시지를 출력할 수 있는 CustomException 객체를 생성할 수 있도록 함. 
  - ErrorType 만 받는 생성자와 ErrorType과 detailMessage를 받는 생성자 2개를 생성하여 예외 상황에 대해 좀 더 디테일한 정보가 필요할 때 detailMessage를 이용할 수 있도록 함 
    ->  ExceptionResponseDto 에서 사용자에게 응답은 ErrorType 메세지만 보여주고 에러 로그에 detailMessage 를 기록하도록 로직 구성함.
- ExceptionResponseDto 생성
  - ExceptionResponseDto 를 통해 미리 정의한 형식으로 사용자에게 응답할 수 있도록 함. 
- GlobalExceptionHandler 생성
  - 예외발생 시 개발자가 예외처리 로직을 신경쓰지 않고 중앙에서 관리할 수 있도록 함. 
- ErrorType
  - enum 클래스를 통해 정형화된 예외데이터를 저장할 수 있도록 함. 

## 🔍 리뷰 요청 사항 및 공유자료
일단은 global/exception 패키지에 다 넣어놨는데 분리가 필요할까요? 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<3분~5분>
