### PR TITLE
[FEAT/global] aop를 이용한 http status 처리

### DIFF
--- a/src/main/java/com/bugzero/rarego/global/aspect/ResponseAspect.java
+++ b/src/main/java/com/bugzero/rarego/global/aspect/ResponseAspect.java
@@ -1,0 +1,58 @@
+package com.bugzero.rarego.global.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.standard.response.ResponseDto;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * API 응답 처리용 Aspect
+ * 컨트롤러나 예외 핸들러가 반환하는 ResponseDto 객체를 가로채서,
+ * DTO 내부에 정의된 상태 코드(status)를 실제 HTTP 응답의 상태 코드로 설정합니다.
+ * 이를 통해 컨트롤러나 예외 핸들러에서 ResponseEntity로 감싸지 않고 Dto만 반환해도 올바른 HTTP Status가 전송됩니다.
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ResponseAspect {
+	private final HttpServletResponse response;
+
+	@Pointcut("within(@org.springframework.web.bind.annotation.RestController *) || " +
+		"within(@org.springframework.web.bind.annotation.RestControllerAdvice *)")
+	public void controllerOrAdvice() {
+	}
+
+	@Pointcut("@annotation(org.springframework.web.bind.annotation.GetMapping) || " +
+		"@annotation(org.springframework.web.bind.annotation.PostMapping) || " +
+		"@annotation(org.springframework.web.bind.annotation.PutMapping) || " +
+		"@annotation(org.springframework.web.bind.annotation.DeleteMapping) || " +
+		"@annotation(org.springframework.web.bind.annotation.PatchMapping) || " +
+		"@annotation(org.springframework.web.bind.annotation.RequestMapping)")
+	public void httpMapping() {
+	}
+
+	@Pointcut("@annotation(org.springframework.web.bind.annotation.ExceptionHandler)")
+	public void exceptionHandler() {
+	}
+
+	@Pointcut("@annotation(org.springframework.web.bind.annotation.ResponseBody)")
+	public void responseBody() {
+	}
+
+	@Around("(controllerOrAdvice() && (httpMapping() || exceptionHandler())) || responseBody()")
+	public Object responseAspect(ProceedingJoinPoint joinPoint) throws Throwable {
+		Object result = joinPoint.proceed();
+
+		if (result instanceof ResponseDto responseDto) {
+			response.setStatus(responseDto.status());
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/com/bugzero/rarego/global/exception/CustomException.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/CustomException.java
@@ -1,5 +1,7 @@
 package com.bugzero.rarego.global.exception;
 
+import com.bugzero.rarego.global.response.ErrorType;
+
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/bugzero/rarego/global/exception/ExceptionResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/ExceptionResponseDto.java
@@ -1,6 +1,8 @@
 package com.bugzero.rarego.global.exception;
 
-public record ExceptionResponseDto(Integer status, String message) {
+import com.bugzero.rarego.standard.response.ResponseDto;
+
+public record ExceptionResponseDto(Integer status, String message) implements ResponseDto {
 
 	public static ExceptionResponseDto to(Integer status, String message) {
 		return new ExceptionResponseDto(status, message);

--- a/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
@@ -1,20 +1,18 @@
 package com.bugzero.rarego.global.exception;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import lombok.extern.slf4j.Slf4j;
 
-@ControllerAdvice
+@RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
-	public ResponseEntity<ExceptionResponseDto> handleCustomException(CustomException e) {
+	public ExceptionResponseDto handleCustomException(CustomException e) {
 		log.error("CustomException 발생: {}", e.getMessage());
-		return ResponseEntity.status(e.getErrorType().getHttpStatus())
-			.body(ExceptionResponseDto.to(e.getErrorType().getHttpStatus(), e.getErrorType().getMessage()));
+		return ExceptionResponseDto.to(e.getErrorType().getHttpStatus(), e.getErrorType().getMessage());
 	}
 
 }

--- a/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.bugzero.rarego.global.exception;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.bugzero.rarego.global.response.ExceptionResponseDto;
+
 import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice

--- a/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
@@ -1,4 +1,4 @@
-package com.bugzero.rarego.global.exception;
+package com.bugzero.rarego.global.response;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bugzero/rarego/global/response/ExceptionResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ExceptionResponseDto.java
@@ -1,4 +1,4 @@
-package com.bugzero.rarego.global.exception;
+package com.bugzero.rarego.global.response;
 
 import com.bugzero.rarego.standard.response.ResponseDto;
 

--- a/src/main/java/com/bugzero/rarego/global/response/PageDto.java
+++ b/src/main/java/com/bugzero/rarego/global/response/PageDto.java
@@ -1,0 +1,23 @@
+package com.bugzero.rarego.global.response;
+
+import org.springframework.data.domain.Page;
+
+public record PageDto(
+	int currentPage,
+	int limit,
+	long totalItems,
+	int totalPages,
+	boolean hasNext,
+	boolean hasPrevious
+) {
+	public static PageDto from(Page<?> page) {
+		return new PageDto(
+			page.getNumber() + 1, // 페이지 번호는 0부터 시작하므로 +1
+			page.getSize(),
+			page.getTotalElements(),
+			page.getTotalPages(),
+			page.hasNext(),
+			page.hasPrevious()
+		);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/global/response/PagedResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/global/response/PagedResponseDto.java
@@ -1,0 +1,14 @@
+package com.bugzero.rarego.global.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+public record PagedResponseDto<T>(
+	List<T> data,
+	PageDto pageDto
+) {
+	public static <T> PagedResponseDto<T> from(Page<T> page) {
+		return new PagedResponseDto<>(page.getContent(), PageDto.from(page));
+	}
+}

--- a/src/main/java/com/bugzero/rarego/global/response/SuccessResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/global/response/SuccessResponseDto.java
@@ -1,10 +1,12 @@
 package com.bugzero.rarego.global.response;
 
+import com.bugzero.rarego.standard.response.ResponseDto;
+
 public record SuccessResponseDto<T>(
 	Integer status,
 	String message,
 	T data
-) {
+) implements ResponseDto {
 	// SuccessType만 받는 경우 (data 없음)
 	public static SuccessResponseDto<Void> from(SuccessType successType) {
 		return new SuccessResponseDto<>(

--- a/src/main/java/com/bugzero/rarego/standard/response/ResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/standard/response/ResponseDto.java
@@ -1,0 +1,7 @@
+package com.bugzero.rarego.standard.response;
+
+public interface ResponseDto {
+	Integer status();
+
+	String message();
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #17

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

- [x] aop를 이용해서 컨트롤러와 예외 처리기에서 응답을 가로채서 상태코드를 자동으로 status로 설정합니다.
- [x] 공통 응답 인터페이스를 작성해서 에러 응답 객체와 성공 응답 객체에서 상속받게 했습니다.
- [x] GlobalExceptionHandler에서 ResponseEntity로 감싸서 반환하는 것이 아닌 저희 응답 객체를 반환하도록 수정했습니다.

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
security filter에서 발생하는 예외는 컨트롤러 단에서 발생하는 것이 아니기 때문에 자동으로 status가 설정되지 않습니다. 수동으로 설정해야합니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분
