### PR TITLE
[FEAT/global] 공통 응답 페이지 추가

### DIFF
--- a/src/main/java/com/bugzero/rarego/global/exception/CustomException.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/CustomException.java
@@ -1,5 +1,7 @@
 package com.bugzero.rarego.global.exception;
 
+import com.bugzero.rarego.global.response.ErrorType;
+
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import com.bugzero.rarego.global.response.ExceptionResponseDto;
+
 import lombok.extern.slf4j.Slf4j;
 
 @ControllerAdvice

--- a/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
@@ -1,4 +1,4 @@
-package com.bugzero.rarego.global.exception;
+package com.bugzero.rarego.global.response;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/bugzero/rarego/global/response/ExceptionResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ExceptionResponseDto.java
@@ -1,4 +1,4 @@
-package com.bugzero.rarego.global.exception;
+package com.bugzero.rarego.global.response;
 
 public record ExceptionResponseDto(Integer status, String message) {
 

--- a/src/main/java/com/bugzero/rarego/global/response/PageDto.java
+++ b/src/main/java/com/bugzero/rarego/global/response/PageDto.java
@@ -1,0 +1,23 @@
+package com.bugzero.rarego.global.response;
+
+import org.springframework.data.domain.Page;
+
+public record PageDto(
+	int currentPage,
+	int limit,
+	long totalItems,
+	int totalPages,
+	boolean hasNext,
+	boolean hasPrevious
+) {
+	public static PageDto from(Page<?> page) {
+		return new PageDto(
+			page.getNumber() + 1, // 페이지 번호는 0부터 시작하므로 +1
+			page.getSize(),
+			page.getTotalElements(),
+			page.getTotalPages(),
+			page.hasNext(),
+			page.hasPrevious()
+		);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/global/response/PagedResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/global/response/PagedResponseDto.java
@@ -1,0 +1,14 @@
+package com.bugzero.rarego.global.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+public record PagedResponseDto<T>(
+	List<T> data,
+	PageDto pageDto
+) {
+	public static <T> PagedResponseDto<T> from(Page<T> page) {
+		return new PagedResponseDto<>(page.getContent(), PageDto.from(page));
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #16 

## 🚀 작업 내용
- PageDto 
  - 페이지 메타데이터를 약속된 형식에 맞게 저장
  - hasNext(), hasPrevious() 값을 통해 프론트엔드에서 다음, 이전 버튼을 활성화할 수 있도록 함. 
- PageResponseDto
  - 메타데이터와 실제데이터를 응답 규격 설정  
- PageDto 가 페이지 계산 및 정보 전달에만 집중하게 함으로써 책임을 분리, 유지보수성을 향상시킬 수 있음. 
## 🔍 리뷰 요청 사항 및 공유자료
- 클래스 네이밍 괜찮을까요? 

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션을 지켰습니다.
- [X] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
3분
