### PR TITLE
[FEAT/product] Product 도메인 JPA 엔티티, 레포지토리 생성

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Category.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Category.java
@@ -1,0 +1,7 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+public enum Category {
+	스타워즈,
+	오리지널,
+	해리포터
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/InspectionStatus.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/InspectionStatus.java
@@ -1,0 +1,7 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+public enum InspectionStatus {
+	PENDING,
+	APPROVED,
+	REJECTED
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Product.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Product.java
@@ -1,10 +1,15 @@
 package com.bugzero.rarego.boundedContext.product.domain;
 
+import java.util.List;
+
 import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Table(name = "PRODUCT_PRODUCT")
 @Builder
 public class Product extends BaseIdAndTime {
 	//TODO 복제 멤버 엔티티 생성 후 변경
@@ -24,6 +30,13 @@ public class Product extends BaseIdAndTime {
 	private ProductCondition productCondition;
 	@Enumerated(EnumType.STRING)
 	private InspectionStatus inspectionStatus;
+	@OneToMany(mappedBy = "product", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+	List<ProductImage> images;
 	private String name;
 	private String description;
+
+	//TODO 추후 상품이미지 등록 로직에 따라 파라미터 값 변경 예정
+	public void addImage(ProductImage image) {
+		this.images.add(image);
+	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Product.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Product.java
@@ -1,0 +1,29 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class Product extends BaseIdAndTime {
+	//TODO 복제 멤버 엔티티 생성 후 변경
+	private long sellerId;
+	@Enumerated(EnumType.STRING)
+	private Category category;
+	@Enumerated(EnumType.STRING)
+	private ProductCondition productCondition;
+	@Enumerated(EnumType.STRING)
+	private InspectionStatus inspectionStatus;
+	private String name;
+	private String description;
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Product.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Product.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -32,6 +33,7 @@ public class Product extends BaseIdAndTime {
 	private InspectionStatus inspectionStatus;
 	@OneToMany(mappedBy = "product", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
 	List<ProductImage> images;
+	@Column(length = 100, nullable = false)
 	private String name;
 	private String description;
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductCondition.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductCondition.java
@@ -1,0 +1,16 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ProductCondition {
+	MISB("박스 상태가 완벽하고 인장이 그대로 붙어 있는 최상급 상태"),
+	NISB("새 제품이지만 박스에 약간의 구겨짐이나 흠집이 있는 상태"),
+	MISP("비닐 팩 형태의 제품이 미개봉 상태"),
+	USED("조립 후 전시했거나 보관 중인 상태")
+	;
+
+	private final String description;
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductImage.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductImage.java
@@ -2,6 +2,7 @@ package com.bugzero.rarego.boundedContext.product.domain;
 
 import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -23,6 +24,7 @@ public class ProductImage extends BaseIdAndTime {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "product_id", nullable = false)
 	private Product	product;
+	@Column(length = 500, nullable = false)
 	private String imageUrl;
 	private boolean isThumbnail;
 	private int sortOrder;

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductImage.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductImage.java
@@ -1,0 +1,30 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Table(name = "PRODUCT_IMAGE")
+@Builder
+public class ProductImage extends BaseIdAndTime {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "product_id", nullable = false)
+	private Product	product;
+	private String imageUrl;
+	private boolean isThumbnail;
+	private int sortOrder;
+
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/out/ProductImageRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/out/ProductImageRepository.java
@@ -1,0 +1,8 @@
+package com.bugzero.rarego.boundedContext.product.out;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bugzero.rarego.boundedContext.product.domain.ProductImage;
+
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/out/ProductRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/out/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.bugzero.rarego.boundedContext.product.out;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bugzero.rarego.boundedContext.product.domain.Product;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #21 

## 🚀 작업 내용
- `Product`
  - 상품 데이터 엔티티
  - sellerId는 추후 ProductMember(멤버 복제 데이터) 생성 후 변경 예정
- `Category`
  - 레고 상품을 등록할 때 해당 상품의 테마가 무엇인지 쉽게 알 수 있도록 하고 필터링을 쉽게 구현할 수 있도록 합니다. 
  - ex) 스타워즈 테마에만 관심이 있다면 해당 속성값을 통해 스타워즈 제품을 쉽게 필터링할 수 있습니다. 
- `ProductCondition`
  - 상품 보존 상태를 분류할 수 있는 enum 클래스입니다. 
- `InspectionStatus`
  - 상품의 검수 상태를 알려줍니다. 검수 승인된 상품 데이터만 일반사용자들이 확인할 수 있습니다.  

- [x] Product 도메인 jpa 엔티티, 레포지토리 생성
- [x] Product 관련 enum 클래스 생성

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
2뷴
