### PR TITLE
[FEAT/auction] Auction 도메인 JPA 엔티티 구현

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Auction.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Auction.java
@@ -1,0 +1,53 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Auction extends BaseIdAndTime {
+
+	@Column(nullable = false)
+	private BigInteger productId;
+
+	private LocalDateTime startTime;
+
+	private LocalDateTime endTime;
+
+	@Enumerated(EnumType.STRING)
+	private AuctionStatus status;
+
+	private Integer startPrice;
+
+	private Integer currentPrice;
+
+	private Integer tickSize;
+
+	@Version // 낙관적 락
+	private Long version;
+
+	@Builder
+	public Auction(BigInteger productId, LocalDateTime startTime, LocalDateTime endTime, Integer startPrice, Integer tickSize) {
+		this.productId = productId;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.startPrice = startPrice;
+		this.tickSize = tickSize;
+		this.status = AuctionStatus.SCHEDULED; // 기본값 설정 용이
+	}
+
+	// 입찰 가격 갱신
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionBookmark.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionBookmark.java
@@ -1,0 +1,35 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+import java.math.BigInteger;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AuctionBookmark extends BaseIdAndTime {
+
+	@Column(nullable = false)
+	private BigInteger auctionId;
+
+	@Column(nullable = false)
+	private BigInteger memberId;
+
+	@Column(nullable = false)
+	private BigInteger productId;
+
+	@Builder
+	public AuctionBookmark(BigInteger auctionId, BigInteger memberId, BigInteger productId) {
+		this.auctionId = auctionId;
+		this.memberId = memberId;
+		this.productId = productId;
+	}
+
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrder.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrder.java
@@ -1,0 +1,43 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AuctionOrder extends BaseIdAndTime {
+
+	@Column(nullable = false)
+	private BigInteger auctionId;
+
+	@Column(nullable = false)
+	private BigInteger bidderId;
+
+	private LocalDateTime bidTime;
+
+	private Integer bidAmount;
+
+	private Integer finalPrice;
+
+	private AuctionOrderStatus status;
+
+	@Builder
+	public AuctionOrder(BigInteger auctionId, BigInteger bidderId, Integer bidAmount) {
+		this.auctionId = auctionId;
+		this.bidderId = bidderId;
+		this.bidAmount = bidAmount;
+		this.bidTime = LocalDateTime.now(); // 입찰 시각 설정
+	}
+
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrderStatus.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrderStatus.java
@@ -1,0 +1,7 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+public enum AuctionOrderStatus {
+	PROCESSING,
+	SUCCESS,
+	FAILED
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionStatus.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionStatus.java
@@ -1,0 +1,9 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+public enum AuctionStatus {
+	SCHEDULED,      // 예정됨
+	IN_PROGRESS,    // 진행 중
+	ENDED,          // 종료됨 (시간 만료)
+	SOLD,           // 낙찰됨 (구매 확정)
+	FAILED          // 유찰됨
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #23 

## 🚀 작업 내용

- Auction
경매 관련 엔티티
productId는 추후에 상품 테이블 id와 연결 예정

- AuctionOrder
낙찰 기록 관련 엔티티
auctionId와 bidderId도 일단은 객체 참조 대신 직접 필드를 갖도록 구현. 개발 과정에 따라 변경 가능

- AuctionBookmark
관심 경매 관련 엔티티
이 부분도 auctionId, memberId, productId를 추후에 객체 참조하도록 변경 예정

- AuctionStatus
경매 진행 상태 관련 enum 클래스입니다. 현재 ENDED와 SOLD를 넣은 상태입니다.

- AuctionOrderStatus
낙찰 결제 상태 관련 enum 클래스입니다.


- [ ] Auction 도메인 jpa 엔티티 생성
- [ ] Auction 관련 enum 생성

## 🔍 리뷰 요청 사항 및 공유자료
현재 참조가 명확하지 않아서 일단 다른 테이블 관련 ID 모두 직접 필드로 구현했는데 추후에 모두 다 객체 참조를 하도록 변경하는 것이 나을까요?

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분
