### PR TITLE
[FEAT/auction] Auction 도메인 JPA 엔티티, 레포지터리 구현

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Auction.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Auction.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 public class Auction extends BaseIdAndTime {
 
 	@Column(nullable = false)
-	private BigInteger productId;
+	private Long productId;
 
 	private LocalDateTime startTime;
 
@@ -30,17 +30,17 @@ public class Auction extends BaseIdAndTime {
 	@Enumerated(EnumType.STRING)
 	private AuctionStatus status;
 
-	private Integer startPrice;
+	private int startPrice;
 
-	private Integer currentPrice;
+	private int currentPrice;
 
-	private Integer tickSize;
+	private int tickSize;
 
 	@Version // 낙관적 락
 	private Long version;
 
 	@Builder
-	public Auction(BigInteger productId, LocalDateTime startTime, LocalDateTime endTime, Integer startPrice, Integer tickSize) {
+	public Auction(Long productId, LocalDateTime startTime, LocalDateTime endTime, int startPrice, int tickSize) {
 		this.productId = productId;
 		this.startTime = startTime;
 		this.endTime = endTime;

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Auction.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Auction.java
@@ -1,0 +1,53 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Auction extends BaseIdAndTime {
+
+	@Column(nullable = false)
+	private BigInteger productId;
+
+	private LocalDateTime startTime;
+
+	private LocalDateTime endTime;
+
+	@Enumerated(EnumType.STRING)
+	private AuctionStatus status;
+
+	private Integer startPrice;
+
+	private Integer currentPrice;
+
+	private Integer tickSize;
+
+	@Version // 낙관적 락
+	private Long version;
+
+	@Builder
+	public Auction(BigInteger productId, LocalDateTime startTime, LocalDateTime endTime, Integer startPrice, Integer tickSize) {
+		this.productId = productId;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.startPrice = startPrice;
+		this.tickSize = tickSize;
+		this.status = AuctionStatus.SCHEDULED; // 기본값 설정 용이
+	}
+
+	// 입찰 가격 갱신
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionBookmark.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionBookmark.java
@@ -1,7 +1,5 @@
 package com.bugzero.rarego.boundedContext.auction.domain;
 
-import java.math.BigInteger;
-
 import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
 
 import jakarta.persistence.Column;
@@ -17,16 +15,16 @@ import lombok.NoArgsConstructor;
 public class AuctionBookmark extends BaseIdAndTime {
 
 	@Column(nullable = false)
-	private BigInteger auctionId;
+	private Long auctionId;
 
 	@Column(nullable = false)
-	private BigInteger memberId;
+	private Long memberId;
 
 	@Column(nullable = false)
-	private BigInteger productId;
+	private Long productId;
 
 	@Builder
-	public AuctionBookmark(BigInteger auctionId, BigInteger memberId, BigInteger productId) {
+	public AuctionBookmark(Long auctionId, Long memberId, Long productId) {
 		this.auctionId = auctionId;
 		this.memberId = memberId;
 		this.productId = productId;

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionBookmark.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionBookmark.java
@@ -1,0 +1,35 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+import java.math.BigInteger;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AuctionBookmark extends BaseIdAndTime {
+
+	@Column(nullable = false)
+	private BigInteger auctionId;
+
+	@Column(nullable = false)
+	private BigInteger memberId;
+
+	@Column(nullable = false)
+	private BigInteger productId;
+
+	@Builder
+	public AuctionBookmark(BigInteger auctionId, BigInteger memberId, BigInteger productId) {
+		this.auctionId = auctionId;
+		this.memberId = memberId;
+		this.productId = productId;
+	}
+
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrder.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrder.java
@@ -1,0 +1,43 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class AuctionOrder extends BaseIdAndTime {
+
+	@Column(nullable = false)
+	private BigInteger auctionId;
+
+	@Column(nullable = false)
+	private BigInteger bidderId;
+
+	private LocalDateTime bidTime;
+
+	private Integer bidAmount;
+
+	private Integer finalPrice;
+
+	private AuctionOrderStatus status;
+
+	@Builder
+	public AuctionOrder(BigInteger auctionId, BigInteger bidderId, Integer bidAmount) {
+		this.auctionId = auctionId;
+		this.bidderId = bidderId;
+		this.bidAmount = bidAmount;
+		this.bidTime = LocalDateTime.now(); // 입찰 시각 설정
+	}
+
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrderStatus.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrderStatus.java
@@ -1,0 +1,7 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+public enum AuctionOrderStatus {
+	PROCESSING,
+	SUCCESS,
+	FAILED
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrderStatus.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrderStatus.java
@@ -1,7 +1,10 @@
 package com.bugzero.rarego.boundedContext.auction.domain;
 
 public enum AuctionOrderStatus {
+	// 결제 진행중
 	PROCESSING,
+	// 결제 성공
 	SUCCESS,
+	// 결제 실패
 	FAILED
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionStatus.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionStatus.java
@@ -1,0 +1,9 @@
+package com.bugzero.rarego.boundedContext.auction.domain;
+
+public enum AuctionStatus {
+	SCHEDULED,      // 예정됨
+	IN_PROGRESS,    // 진행 중
+	ENDED,          // 종료됨 (시간 만료)
+	SOLD,           // 낙찰됨 (구매 확정)
+	FAILED          // 유찰됨
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionStatus.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionStatus.java
@@ -1,9 +1,14 @@
 package com.bugzero.rarego.boundedContext.auction.domain;
 
 public enum AuctionStatus {
-	SCHEDULED,      // 예정됨
-	IN_PROGRESS,    // 진행 중
-	ENDED,          // 종료됨 (시간 만료)
-	SOLD,           // 낙찰됨 (구매 확정)
-	FAILED          // 유찰됨
+	// 예정됨
+	SCHEDULED,
+	// 진행 중
+	IN_PROGRESS,
+	// 종료됨 (시간 만료)
+	ENDED,
+	// 낙찰됨 (구매 확정)
+	SOLD,
+	// 유찰됨
+	FAILED
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Bid.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Bid.java
@@ -1,6 +1,5 @@
 package com.bugzero.rarego.boundedContext.auction.domain;
 
-import java.math.BigInteger;
 import java.time.LocalDateTime;
 
 import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
@@ -12,11 +11,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class AuctionOrder extends BaseIdAndTime {
+public class Bid extends BaseIdAndTime {
 
 	@Column(nullable = false)
 	private Long auctionId;
@@ -28,16 +26,11 @@ public class AuctionOrder extends BaseIdAndTime {
 
 	private int bidAmount;
 
-	private int finalPrice;
-
-	private AuctionOrderStatus status;
-
 	@Builder
-	public AuctionOrder(Long auctionId, Long bidderId, int bidAmount) {
+	public Bid(Long auctionId, Long bidderId, int bidAmount) {
 		this.auctionId = auctionId;
 		this.bidderId = bidderId;
 		this.bidAmount = bidAmount;
 		this.bidTime = LocalDateTime.now();
 	}
-
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/out/BidRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/out/BidRepository.java
@@ -1,0 +1,11 @@
+package com.bugzero.rarego.boundedContext.auction.out;
+
+import com.bugzero.rarego.boundedContext.auction.domain.Bid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BidRepository extends JpaRepository<Bid, Long> {
+	// auctionId를 기준으로 필드명을 검색
+	Page<Bid> findAllByAuctionIdOrderByBidTimeDesc(Long auctionId, Pageable pageable);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #23 

## 🚀 작업 내용

- Auction
경매 관련 엔티티
productId는 추후에 상품 테이블 id와 연결 예정

- AuctionOrder
낙찰 기록 관련 엔티티
auctionId와 bidderId도 일단은 객체 참조 대신 직접 필드를 갖도록 구현. 개발 과정에 따라 변경 가능

- AuctionBookmark
관심 경매 관련 엔티티
이 부분도 auctionId, memberId, productId를 추후에 객체 참조하도록 변경 예정

- AuctionStatus
경매 진행 상태 관련 enum 클래스입니다. 현재 ENDED와 SOLD를 넣은 상태입니다.

- AuctionOrderStatus
낙찰 결제 상태 관련 enum 클래스입니다.

- Bid
입찰 기록 관련 엔티티
이 부분도 auctionId, bidderId를 일단 직접 필드로 구현했습니다.

- BidRepository
입찰 관련 JPA 레포지터리


- [ ] Auction 도메인 jpa 엔티티, 레포지터리 생성
- [ ] Auction 관련 enum 생성

## 🔍 리뷰 요청 사항 및 공유자료
추후에 객체 참조 관계를 판단하고 변경 예정이라 일단 직접 필드로 구현했습니다.

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분