### PR TITLE
[FEAT/auth] 인증 (refreshToken) JPA 엔티티, 레포지토리 구현

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auth/domain/RefreshToken.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auth/domain/RefreshToken.java
@@ -17,7 +17,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "AUTH_REFRESH_TOKEN",
 	indexes = {
 		@Index(name = "idx_auth_refresh_token_member_id", columnList = "member_id"),
-		@Index(name = "idx_auth_refresh_token_expires_at", columnList = "expires_at"),
 		@Index(name = "idx_auth_refresh_token_revoked_expires", columnList = "revoked, expires_at")
 	}
 )

--- a/src/main/java/com/bugzero/rarego/boundedContext/auth/domain/RefreshToken.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auth/domain/RefreshToken.java
@@ -1,0 +1,48 @@
+package com.bugzero.rarego.boundedContext.auth.domain;
+
+import java.time.LocalDateTime;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "AUTH_REFRESH_TOKEN",
+	indexes = {
+		@Index(name = "idx_auth_refresh_token_member_id", columnList = "member_id"),
+		@Index(name = "idx_auth_refresh_token_expires_at", columnList = "expires_at"),
+		@Index(name = "idx_auth_refresh_token_revoked_expires", columnList = "revoked, expires_at")
+	}
+)
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseIdAndTime {
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "refresh_token_hash", nullable = false, length = 255)
+	private String refreshTokenHash;
+
+	@Column(name = "expires_at", nullable = false)
+	private LocalDateTime expiresAt;
+
+	@Column(name = "revoked", nullable = false)
+	private boolean revoked = false;
+
+	public void revoke() {
+		this.revoked = true;
+	}
+
+	public boolean isExpired(LocalDateTime now) {
+		return expiresAt.isBefore(now);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auth/out/RefreshTokenRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auth/out/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.bugzero.rarego.boundedContext.auth.out;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bugzero.rarego.boundedContext.auth.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #35

## 🚀 작업 내용

- [x] 인증을 위한 refreshToken 엔티티, 저장소를 JPA 형식을 통해 구현했습니다. [(notion ERD 추가)](https://www.notion.so/ERD-2e115a01205481a1b2d0ec1c10c53e8d?source=copy_link)
- [x] 인덱스 기준 (memberId, 폐기를 위한 revoked(로그아웃 폐기) + expiredAt(만료일시))

## 🔍 리뷰 요청 사항 및 공유자료

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
3min +
