### PR TITLE
[FEAT/product] 상품 등록을 위한 DTO 생성

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Product.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/Product.java
@@ -35,6 +35,7 @@ public class Product extends BaseIdAndTime {
 	List<ProductImage> images;
 	@Column(length = 100, nullable = false)
 	private String name;
+	@Column(columnDefinition = "TEXT")
 	private String description;
 
 	//TODO 추후 상품이미지 등록 로직에 따라 파라미터 값 변경 예정

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductAuctionRequestDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductAuctionRequestDto.java
@@ -1,0 +1,7 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+public record ProductAuctionRequestDto(
+	int startPrice,
+	int durationDays
+) {
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductImageRequestDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductImageRequestDto.java
@@ -1,0 +1,7 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+public record ProductImageRequestDto(
+	boolean thumbnail,
+	int sortOrder
+) {
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductRequestDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductRequestDto.java
@@ -1,10 +1,12 @@
 package com.bugzero.rarego.boundedContext.product.domain;
 
+import java.util.List;
+
 public record ProductRequestDto(
 	String name,
 	Category category,
 	String description,
 	ProductAuctionRequestDto productAuctionRequestDto,
-	ProductImageRequestDto productImageRequestDto
+	List<ProductImageRequestDto> productImageRequestDto
 ) {
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductRequestDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductRequestDto.java
@@ -1,0 +1,10 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+public record ProductRequestDto(
+	String name,
+	Category category,
+	String description,
+	ProductAuctionRequestDto productAuctionRequestDto,
+	ProductImageRequestDto productImageRequestDto
+) {
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/domain/ProductResponseDto.java
@@ -1,0 +1,8 @@
+package com.bugzero.rarego.boundedContext.product.domain;
+
+public record ProductResponseDto (
+	long productId,
+	long auctionId,
+	InspectionStatus inspectionStatus
+) {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
 #32 

## 🚀 작업 내용
- ProductRequestDto
  - 상품 기본 정보 등록 요청 dto 입니다. 
- ProductAuctionRequestDto 
  - 상품을 등록할 때 경매 정보도 한 번에 받기로 결정했기 때문에 이를 위한 경매 정보 dto 입니다. 
- ProductImageRequestDto
  - 상품 이미지 정보 등록을 위한 dto 입니다.   
- ProductResponseDto
  - 성공응답을 반환하기 위한 dto 입니다. 
- [ ] 상품 경매 정보를 받기 위한 dto 생성
- [ ] 성공응답을 반환하기 위한 dto 생성

## 🔍 리뷰 요청 사항 및 공유자료
dto를 다 domain 경로에 포함시켰는데 괜찮을까요? 

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션을 지켰습니다.
- [X] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
2분
---

