### PR TITLE
[FEAT/payment] 예치금 결제 요청 api 구현

### DIFF
--- a/src/main/java/com/bugzero/rarego/RaregoApplication.java
+++ b/src/main/java/com/bugzero/rarego/RaregoApplication.java
@@ -2,9 +2,7 @@ package com.bugzero.rarego;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class RaregoApplication {
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
@@ -1,0 +1,18 @@
+package com.bugzero.rarego.boundedContext.payment.app;
+
+import org.springframework.stereotype.Service;
+
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentFacade {
+	private final PaymentRequestPaymentUseCase paymentRequestPaymentUsecase;
+
+	public PaymentRequestResponseDto requestPayment(long memberId, PaymentRequestDto requestDto) {
+		return paymentRequestPaymentUsecase.requestPayment(memberId, requestDto);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
@@ -10,9 +10,9 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PaymentFacade {
-	private final PaymentRequestPaymentUseCase paymentRequestPaymentUsecase;
+	private final PaymentRequestPaymentUseCase paymentRequestPaymentUseCase;
 
 	public PaymentRequestResponseDto requestPayment(long memberId, PaymentRequestDto requestDto) {
-		return paymentRequestPaymentUsecase.requestPayment(memberId, requestDto);
+		return paymentRequestPaymentUseCase.requestPayment(memberId, requestDto);
 	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCase.java
@@ -39,11 +39,6 @@ public class PaymentRequestPaymentUseCase {
 
 		paymentRepository.save(payment);
 
-		return new PaymentRequestResponseDto(
-			orderId,
-			payment.getAmount(),
-			member.getEmail(),
-			member.getNickname()
-		);
+		return PaymentRequestResponseDto.from(payment);
 	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCase.java
@@ -1,0 +1,49 @@
+package com.bugzero.rarego.boundedContext.payment.app;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bugzero.rarego.boundedContext.payment.domain.Payment;
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentStatus;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentRepository;
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentRequestPaymentUseCase {
+	private final PaymentMemberRepository paymentMemberRepository;
+	private final PaymentRepository paymentRepository;
+
+	@Transactional
+	public PaymentRequestResponseDto requestPayment(Long memberId, PaymentRequestDto requestDto) {
+		PaymentMember member = paymentMemberRepository.findById(memberId)
+			.orElseThrow(() -> new CustomException(ErrorType.MEMBER_NOT_FOUND));
+
+		String orderId = UUID.randomUUID().toString();
+
+		Payment payment = Payment.builder()
+			.member(member)
+			.orderId(orderId)
+			.amount(requestDto.amount())
+			.status(PaymentStatus.PENDING)
+			.build();
+
+		paymentRepository.save(payment);
+
+		return new PaymentRequestResponseDto(
+			orderId,
+			payment.getAmount(),
+			member.getEmail(),
+			member.getNickname()
+		);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/domain/Deposit.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/domain/Deposit.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-	name = "payment_deposit",
+	name = "PAYMENT_DEPOSIT",
 	indexes = {
 		@Index(name = "idx_deposit_auction_id", columnList = "auction_id")
 	},

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
@@ -28,6 +28,6 @@ public class PaymentController {
 		@RequestParam Long memberId,
 		@Valid @RequestBody PaymentRequestDto requestDto
 	) {
-		return SuccessResponseDto.from(SuccessType.OK, paymentFacade.requestPayment(memberId, requestDto));
+		return SuccessResponseDto.from(SuccessType.CREATED, paymentFacade.requestPayment(memberId, requestDto));
 	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
@@ -1,0 +1,33 @@
+package com.bugzero.rarego.boundedContext.payment.in;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.bugzero.rarego.boundedContext.payment.app.PaymentFacade;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
+import com.bugzero.rarego.global.response.SuccessResponseDto;
+import com.bugzero.rarego.global.response.SuccessType;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+	private final PaymentFacade paymentFacade;
+
+	@PostMapping("/charges")
+	public SuccessResponseDto<PaymentRequestResponseDto> requestPayment(
+		// TODO: 추후 인증 구현시 @AuthenticationPrincipal로 변경 필요
+		// 현재는 테스트를 위해 Query Parameter로 받음
+		@RequestParam Long memberId,
+		@Valid @RequestBody PaymentRequestDto requestDto
+	) {
+		return SuccessResponseDto.from(SuccessType.OK, paymentFacade.requestPayment(memberId, requestDto));
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentDataInit.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentDataInit.java
@@ -1,0 +1,56 @@
+package com.bugzero.rarego.boundedContext.payment.in;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Profile;
+
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
+import com.bugzero.rarego.shared.member.domain.MemberRole;
+import com.bugzero.rarego.shared.member.domain.Provider;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@Slf4j
+@Profile("dev")
+public class PaymentDataInit {
+	private final PaymentDataInit self;
+	private final PaymentMemberRepository paymentMemberRepository;
+
+	public PaymentDataInit(@Lazy PaymentDataInit self, PaymentMemberRepository paymentMemberRepository) {
+		this.self = self;
+		this.paymentMemberRepository = paymentMemberRepository;
+	}
+
+	@Bean
+	public ApplicationRunner paymentBaseInitDataRunner() {
+		return args -> {
+			self.makeBasePaymentMember();
+		};
+	}
+
+	public void makeBasePaymentMember() {
+		if (paymentMemberRepository.count() > 0)
+			return;
+
+		paymentMemberRepository.save(
+			PaymentMember.builder()
+				.id(1L)
+				.publicId(UUID.randomUUID().toString())
+				.email("test@bugzero.com")
+				.nickname("테스트유저")
+				.role(MemberRole.USER)
+				.provider(Provider.GOOGLE)
+				.providerId("test_provider_id")
+				.createdAt(LocalDateTime.now())
+				.updatedAt(LocalDateTime.now())
+				.build()
+		);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/dto/PaymentRequestDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/dto/PaymentRequestDto.java
@@ -1,0 +1,11 @@
+package com.bugzero.rarego.boundedContext.payment.in.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record PaymentRequestDto(
+	@NotNull(message = "결제 금액은 필수입니다.")
+	@Min(value = 10000, message = "최소 결제 금액은 10,000원입니다.")
+	Integer amount
+) {
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/dto/PaymentRequestResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/dto/PaymentRequestResponseDto.java
@@ -1,0 +1,19 @@
+package com.bugzero.rarego.boundedContext.payment.in.dto;
+
+import com.bugzero.rarego.boundedContext.payment.domain.Payment;
+
+public record PaymentRequestResponseDto(
+	String orderId,
+	int amount,
+	String customerName,
+	String customerEmail
+) {
+	public static PaymentRequestResponseDto from(Payment payment) {
+		return new PaymentRequestResponseDto(
+			payment.getOrderId(),
+			payment.getAmount(),
+			payment.getMember().getNickname(),
+			payment.getMember().getEmail()
+		);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/out/PaymentMemberRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/out/PaymentMemberRepository.java
@@ -1,0 +1,8 @@
+package com.bugzero.rarego.boundedContext.payment.out;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
+
+public interface PaymentMemberRepository extends JpaRepository<PaymentMember, Long> {
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/out/PaymentRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/out/PaymentRepository.java
@@ -1,0 +1,8 @@
+package com.bugzero.rarego.boundedContext.payment.out;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.bugzero.rarego.boundedContext.payment.domain.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/bugzero/rarego/global/config/JpaConfig.java
+++ b/src/main/java/com/bugzero/rarego/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.bugzero.rarego.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.bugzero.rarego.global.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,5 +17,11 @@ public class GlobalExceptionHandler {
 	public ExceptionResponseDto handleCustomException(CustomException e) {
 		log.error("CustomException 발생: {}", e.getMessage());
 		return ExceptionResponseDto.to(e.getErrorType().getHttpStatus(), e.getErrorType().getMessage());
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ExceptionResponseDto handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		log.error("MethodArgumentNotValidException 발생: {}", e.getMessage());
+		return ExceptionResponseDto.to(HttpStatus.BAD_REQUEST.value(), e.getMessage());
 	}
 }

--- a/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/GlobalExceptionHandler.java
@@ -22,6 +22,13 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ExceptionResponseDto handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
 		log.error("MethodArgumentNotValidException 발생: {}", e.getMessage());
-		return ExceptionResponseDto.to(HttpStatus.BAD_REQUEST.value(), e.getMessage());
+
+		// 에러가 발생한 필드 중 첫 번째 필드의 에러 메시지만 가져온다.
+		String errorMessage = e.getBindingResult()
+			.getAllErrors()
+			.getFirst()
+			.getDefaultMessage();
+
+		return ExceptionResponseDto.to(HttpStatus.BAD_REQUEST.value(), errorMessage);
 	}
 }

--- a/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
@@ -1,13 +1,16 @@
 package com.bugzero.rarego.global.response;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum ErrorType {
-	INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.")
-	;
+	INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),
+
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 회원입니다.");
 
 	private final Integer httpStatus;
 	private final String message;

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCaseTest.java
@@ -1,0 +1,92 @@
+package com.bugzero.rarego.boundedContext.payment.app;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.bugzero.rarego.boundedContext.payment.domain.Payment;
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentStatus;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentRepository;
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentRequestPaymentUseCaseTest {
+	@InjectMocks
+	private PaymentRequestPaymentUseCase useCase;
+
+	@Mock
+	private PaymentMemberRepository paymentMemberRepository;
+
+	@Mock
+	private PaymentRepository paymentRepository;
+
+	@Test
+	@DisplayName("예치금 결제 요청 성공 테스트")
+	void requestPayment_success() {
+		// given
+		Long memberId = 1L;
+		Integer amount = 10000;
+		PaymentRequestDto requestDto = new PaymentRequestDto(amount);
+
+		// 가짜 멤버 객체 생성
+		PaymentMember member = PaymentMember.builder().id(memberId).build();
+
+		// repository.findById 호출 시 가짜 멤버 리턴하도록 설정
+		given(paymentMemberRepository.findById(memberId))
+			.willReturn(Optional.of(member));
+
+		// when
+		PaymentRequestResponseDto response = useCase.requestPayment(memberId, requestDto);
+
+		// then
+		// 1. 실제로 DB 저장 메서드가 호출되었는지 검증 & 저장되려던 객체 포획(Capture)
+		ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+		verify(paymentRepository, times(1)).save(paymentCaptor.capture());
+
+		Payment savedPayment = paymentCaptor.getValue();
+
+		// 2. 내부 로직 검증
+		assertThat(savedPayment.getMember()).isEqualTo(member);
+		assertThat(savedPayment.getAmount()).isEqualTo(amount);
+		assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.PENDING);
+		assertThat(savedPayment.getOrderId()).isNotNull();
+
+		// 3. 반환값 검증
+		assertThat(response.amount()).isEqualTo(amount);
+	}
+
+	@Test
+	@DisplayName("결제 요청 실패: 존재하지 않는 회원")
+	void requestPayment_fail_member_not_found() {
+		// given
+		Long memberId = 999L;
+		Integer amount = 10000;
+		PaymentRequestDto requestDto = new PaymentRequestDto(amount);
+
+		// repository가 빈 값을 반환하도록 설정
+		given(paymentMemberRepository.findById(memberId))
+			.willReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> useCase.requestPayment(memberId, requestDto))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorType", ErrorType.MEMBER_NOT_FOUND);
+
+		// 예외 발생 시 저장은 호출되지 않아야 함
+		verify(paymentRepository, never()).save(any());
+	}
+}

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/in/PaymentControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/in/PaymentControllerTest.java
@@ -1,0 +1,112 @@
+package com.bugzero.rarego.boundedContext.payment.in;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.bugzero.rarego.boundedContext.payment.app.PaymentFacade;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
+import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
+import com.bugzero.rarego.global.aspect.ResponseAspect;
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
+import com.bugzero.rarego.global.response.SuccessType;
+
+import tools.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = PaymentController.class)
+@Import(ResponseAspect.class)
+@EnableAspectJAutoProxy
+@AutoConfigureMockMvc(addFilters = false)
+class PaymentControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private PaymentFacade paymentFacade;
+
+	@Test
+	@DisplayName("성공: 결제 요청이 정상 처리되면 HTTP 201과 결과 데이터를 반환한다")
+	void requestPayment_success() throws Exception {
+		// given
+		Long memberId = 1L;
+		Integer amount = 10000;
+		PaymentRequestDto requestDto = new PaymentRequestDto(amount);
+
+		PaymentRequestResponseDto responseDto = new PaymentRequestResponseDto(
+			"ORDER-UUID-1234",
+			amount,
+			"PENDING",
+			"user@example.com"
+		);
+
+		given(paymentFacade.requestPayment(eq(memberId), any(PaymentRequestDto.class)))
+			.willReturn(responseDto);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/payments/charges")
+				.param("memberId", String.valueOf(memberId))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.status").value(SuccessType.CREATED.getHttpStatus()))
+			.andExpect(jsonPath("$.message").value(SuccessType.CREATED.getMessage()))
+			.andExpect(jsonPath("$.data.orderId").value("ORDER-UUID-1234"));
+	}
+
+	@Test
+	@DisplayName("실패: 존재하지 않는 회원(MEMBER_NOT_FOUND)인 경우 HTTP 404를 반환한다")
+	void requestPayment_fail_member_not_found() throws Exception {
+		// given
+		Long memberId = 999L;
+		PaymentRequestDto requestDto = new PaymentRequestDto(10000);
+
+		given(paymentFacade.requestPayment(eq(memberId), any(PaymentRequestDto.class)))
+			.willThrow(new CustomException(ErrorType.MEMBER_NOT_FOUND));
+
+		// when & then
+		mockMvc.perform(post("/api/v1/payments/charges")
+				.param("memberId", String.valueOf(memberId))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andDo(print())
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.status").value(ErrorType.MEMBER_NOT_FOUND.getHttpStatus()))
+			.andExpect(jsonPath("$.message").value(ErrorType.MEMBER_NOT_FOUND.getMessage()));
+	}
+
+	@Test
+	@DisplayName("실패: 유효하지 않은 파라미터(Validation)인 경우 HTTP 400을 반환한다")
+	void requestPayment_fail_validation() throws Exception {
+		// given
+		Long memberId = 1L;
+
+		PaymentRequestDto invalidRequest = new PaymentRequestDto(-500);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/payments/charges")
+				.param("memberId", String.valueOf(memberId))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequest)))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value(400));
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #33

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

- [ ] 예치금 결제 요청 api 구현
- [ ] 테스트 코드 작성

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- validation 관련 에러 핸들러 코드를 추가했습니다.
- 테스트할 때 오류가 나서 JpaAuditing 설정을 따로 config로 뺐습니다.
- 아직 Member 모듈이 구현되지 않아서 원래 PaymentMember는 동기화되어 저장되지만 테스트 용으로 하나 생성하는 코드가 작성되어 있습니다. Member 모듈 개발이 끝나면 수정할 예정입니다.
- 결제 요청을 할 때 임시로 회원 아이디를 Query Parameter로 받도록 구현했습니다. 인증 구현이 완료되면 수정할 예정입니다.

- 실제 api 요청 결과입니다.
<img width="633" height="757" alt="image" src="https://github.com/user-attachments/assets/140fb46f-7d29-44c4-ae38-4b9da6f7bd6e" />
<img width="1348" height="100" alt="image" src="https://github.com/user-attachments/assets/23f81411-ee58-46ab-b314-4faa9ff7e7c8" />

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
20분
