### PR TITLE
[FEAT/payment] PaymentSupport로 조회 코드 분리

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentConfirmFinalizer.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentConfirmFinalizer.java
@@ -12,9 +12,6 @@ import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentConfirmResponseDt
 import com.bugzero.rarego.boundedContext.payment.in.dto.TossPaymentsConfirmResponseDto;
 import com.bugzero.rarego.boundedContext.payment.out.PaymentRepository;
 import com.bugzero.rarego.boundedContext.payment.out.PaymentTransactionRepository;
-import com.bugzero.rarego.boundedContext.payment.out.WalletRepository;
-import com.bugzero.rarego.global.exception.CustomException;
-import com.bugzero.rarego.global.response.ErrorType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,8 +19,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PaymentConfirmFinalizer {
 	private final PaymentRepository paymentRepository;
-	private final WalletRepository walletRepository;
 	private final PaymentTransactionRepository paymentTransactionRepository;
+	private final PaymentSupport paymentSupport;
 
 	@Transactional
 	public PaymentConfirmResponseDto finalizePayment(Payment payment,
@@ -33,8 +30,7 @@ public class PaymentConfirmFinalizer {
 
 		paymentRepository.save(payment); // payment는 영속성 컨텍스트와 연결이 끊긴 상태라 명시적으로 저장
 
-		Wallet wallet = walletRepository.findByMemberId(payment.getMember().getId())
-			.orElseThrow(() -> new CustomException(ErrorType.WALLET_NOT_FOUND));
+		Wallet wallet = paymentSupport.findWalletByMemberId(payment.getMember().getId());
 
 		// 지갑 잔액 증가
 		wallet.addBalance(payment.getAmount());

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentConfirmPaymentUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentConfirmPaymentUseCase.java
@@ -22,6 +22,7 @@ public class PaymentConfirmPaymentUseCase {
 	private final TossPaymentsApiClient tossPaymentsApiClient;
 	private final PaymentRepository paymentRepository;
 	private final PaymentConfirmFinalizer paymentConfirmFinalizer;
+	private final PaymentSupport paymentSupport;
 
 	public PaymentConfirmResponseDto confirmPayment(Long memberId, PaymentConfirmRequestDto requestDto) {
 		try {
@@ -37,8 +38,7 @@ public class PaymentConfirmPaymentUseCase {
 	}
 
 	private Payment validateRequest(Long memberId, PaymentConfirmRequestDto requestDto) {
-		Payment payment = paymentRepository.findByOrderId(requestDto.orderId())
-			.orElseThrow(() -> new CustomException(ErrorType.PAYMENT_NOT_FOUND));
+		Payment payment = paymentSupport.findPaymentByOrderId(requestDto.orderId());
 
 		// 내 주문이 맞는지 확인
 		if (!payment.getMember().getId().equals(memberId)) {

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentHoldDepositUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentHoldDepositUseCase.java
@@ -3,10 +3,6 @@ package com.bugzero.rarego.boundedContext.payment.app;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.bugzero.rarego.global.exception.CustomException;
-import com.bugzero.rarego.global.response.ErrorType;
-import com.bugzero.rarego.shared.payment.dto.DepositHoldRequestDto;
-import com.bugzero.rarego.shared.payment.dto.DepositHoldResponseDto;
 import com.bugzero.rarego.boundedContext.payment.domain.Deposit;
 import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
 import com.bugzero.rarego.boundedContext.payment.domain.PaymentTransaction;
@@ -14,9 +10,9 @@ import com.bugzero.rarego.boundedContext.payment.domain.ReferenceType;
 import com.bugzero.rarego.boundedContext.payment.domain.Wallet;
 import com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType;
 import com.bugzero.rarego.boundedContext.payment.out.DepositRepository;
-import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
 import com.bugzero.rarego.boundedContext.payment.out.PaymentTransactionRepository;
-import com.bugzero.rarego.boundedContext.payment.out.WalletRepository;
+import com.bugzero.rarego.shared.payment.dto.DepositHoldRequestDto;
+import com.bugzero.rarego.shared.payment.dto.DepositHoldResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,46 +20,43 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PaymentHoldDepositUseCase {
-        private final DepositRepository depositRepository;
-        private final WalletRepository walletRepository;
-        private final PaymentMemberRepository memberRepository;
-        private final PaymentTransactionRepository transactionRepository;
+	private final DepositRepository depositRepository;
+	private final PaymentTransactionRepository transactionRepository;
+	private final PaymentSupport paymentSupport;
 
-        @Transactional
-        public DepositHoldResponseDto holdDeposit(DepositHoldRequestDto request) {
-                // 1. 멱등성 체크
-                return depositRepository.findByMemberIdAndAuctionId(request.memberId(), request.auctionId())
-                                .map(DepositHoldResponseDto::from)
-                                .orElseGet(() -> executeHold(request));
-        }
+	@Transactional
+	public DepositHoldResponseDto holdDeposit(DepositHoldRequestDto request) {
+		// 1. 멱등성 체크
+		return depositRepository.findByMemberIdAndAuctionId(request.memberId(), request.auctionId())
+			.map(DepositHoldResponseDto::from)
+			.orElseGet(() -> executeHold(request));
+	}
 
-        private DepositHoldResponseDto executeHold(DepositHoldRequestDto request) {
-                PaymentMember member = memberRepository.findById(request.memberId())
-                                .orElseThrow(() -> new CustomException(ErrorType.MEMBER_NOT_FOUND));
+	private DepositHoldResponseDto executeHold(DepositHoldRequestDto request) {
+		PaymentMember member = paymentSupport.findMemberById(request.memberId());
 
-                Wallet wallet = walletRepository.findByMemberId(request.memberId())
-                                .orElseThrow(() -> new CustomException(ErrorType.WALLET_NOT_FOUND));
+		Wallet wallet = paymentSupport.findWalletByMemberId(request.memberId());
 
-                // 2. 잔액 검증 & Wallet 업데이트
-                wallet.hold(request.amount());
+		// 2. 잔액 검증 & Wallet 업데이트
+		wallet.hold(request.amount());
 
-                // 3. Deposit 엔티티 생성 및 저장
-                Deposit deposit = Deposit.create(member, request.auctionId(), request.amount());
-                depositRepository.save(deposit);
+		// 3. Deposit 엔티티 생성 및 저장
+		Deposit deposit = Deposit.create(member, request.auctionId(), request.amount());
+		depositRepository.save(deposit);
 
-                // 4. 이력 기록
-                PaymentTransaction transaction = PaymentTransaction.builder()
-                                .member(member)
-                                .wallet(wallet)
-                                .transactionType(WalletTransactionType.DEPOSIT_HOLD)
-                                .balanceDelta(0)
-                                .holdingDelta(request.amount())
-                                .balanceAfter(wallet.getBalance())
-                                .referenceType(ReferenceType.DEPOSIT)
-                                .referenceId(deposit.getId())
-                                .build();
-                transactionRepository.save(transaction);
+		// 4. 이력 기록
+		PaymentTransaction transaction = PaymentTransaction.builder()
+			.member(member)
+			.wallet(wallet)
+			.transactionType(WalletTransactionType.DEPOSIT_HOLD)
+			.balanceDelta(0)
+			.holdingDelta(request.amount())
+			.balanceAfter(wallet.getBalance())
+			.referenceType(ReferenceType.DEPOSIT)
+			.referenceId(deposit.getId())
+			.build();
+		transactionRepository.save(transaction);
 
-                return DepositHoldResponseDto.from(deposit);
-        }
+		return DepositHoldResponseDto.from(deposit);
+	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCase.java
@@ -10,23 +10,19 @@ import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
 import com.bugzero.rarego.boundedContext.payment.domain.PaymentStatus;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
-import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
 import com.bugzero.rarego.boundedContext.payment.out.PaymentRepository;
-import com.bugzero.rarego.global.exception.CustomException;
-import com.bugzero.rarego.global.response.ErrorType;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentRequestPaymentUseCase {
-	private final PaymentMemberRepository paymentMemberRepository;
 	private final PaymentRepository paymentRepository;
+	private final PaymentSupport paymentSupport;
 
 	@Transactional
 	public PaymentRequestResponseDto requestPayment(Long memberId, PaymentRequestDto requestDto) {
-		PaymentMember member = paymentMemberRepository.findById(memberId)
-			.orElseThrow(() -> new CustomException(ErrorType.MEMBER_NOT_FOUND));
+		PaymentMember member = paymentSupport.findMemberById(memberId);
 
 		String orderId = UUID.randomUUID().toString();
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSupport.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSupport.java
@@ -1,0 +1,37 @@
+package com.bugzero.rarego.boundedContext.payment.app;
+
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.boundedContext.payment.domain.Payment;
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
+import com.bugzero.rarego.boundedContext.payment.domain.Wallet;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentRepository;
+import com.bugzero.rarego.boundedContext.payment.out.WalletRepository;
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentSupport {
+	private final WalletRepository walletRepository;
+	private final PaymentRepository paymentRepository;
+	private final PaymentMemberRepository paymentMemberRepository;
+
+	public Wallet findWalletByMemberId(Long memberId) {
+		return walletRepository.findByMemberId(memberId)
+			.orElseThrow(() -> new CustomException(ErrorType.WALLET_NOT_FOUND));
+	}
+
+	public Payment findPaymentByOrderId(String orderId) {
+		return paymentRepository.findByOrderId(orderId)
+			.orElseThrow(() -> new CustomException(ErrorType.PAYMENT_NOT_FOUND));
+	}
+
+	public PaymentMember findMemberById(Long id) {
+		return paymentMemberRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorType.MEMBER_NOT_FOUND));
+	}
+}

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentHoldDepositUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentHoldDepositUseCaseTest.java
@@ -2,7 +2,7 @@ package com.bugzero.rarego.boundedContext.payment.app;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 import java.util.Optional;
 
@@ -13,19 +13,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.bugzero.rarego.global.exception.CustomException;
-import com.bugzero.rarego.global.response.ErrorType;
-import com.bugzero.rarego.shared.payment.dto.DepositHoldRequestDto;
-import com.bugzero.rarego.shared.payment.dto.DepositHoldResponseDto;
 import com.bugzero.rarego.boundedContext.payment.domain.Deposit;
 import com.bugzero.rarego.boundedContext.payment.domain.DepositStatus;
 import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
 import com.bugzero.rarego.boundedContext.payment.domain.PaymentTransaction;
 import com.bugzero.rarego.boundedContext.payment.domain.Wallet;
 import com.bugzero.rarego.boundedContext.payment.out.DepositRepository;
-import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
 import com.bugzero.rarego.boundedContext.payment.out.PaymentTransactionRepository;
-import com.bugzero.rarego.boundedContext.payment.out.WalletRepository;
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
+import com.bugzero.rarego.shared.payment.dto.DepositHoldRequestDto;
+import com.bugzero.rarego.shared.payment.dto.DepositHoldResponseDto;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentHoldDepositUseCaseTest {
@@ -37,13 +35,10 @@ class PaymentHoldDepositUseCaseTest {
 	private DepositRepository depositRepository;
 
 	@Mock
-	private WalletRepository walletRepository;
-
-	@Mock
-	private PaymentMemberRepository memberRepository;
-
-	@Mock
 	private PaymentTransactionRepository transactionRepository;
+
+	@Mock
+	private PaymentSupport paymentSupport;
 
 	@Test
 	@DisplayName("보증금 홀딩 성공")
@@ -54,8 +49,8 @@ class PaymentHoldDepositUseCaseTest {
 		Wallet wallet = Wallet.builder().balance(100000).holdingAmount(0).build();
 
 		when(depositRepository.findByMemberIdAndAuctionId(4L, 3L)).thenReturn(Optional.empty());
-		when(memberRepository.findById(4L)).thenReturn(Optional.of(member));
-		when(walletRepository.findByMemberId(4L)).thenReturn(Optional.of(wallet));
+		given(paymentSupport.findMemberById(4L)).willReturn(member);
+		given(paymentSupport.findWalletByMemberId(4L)).willReturn(wallet);
 
 		// when
 		DepositHoldResponseDto response = paymentHoldDepositUseCase.holdDeposit(request);
@@ -77,8 +72,8 @@ class PaymentHoldDepositUseCaseTest {
 		Wallet wallet = Wallet.builder().balance(10000).holdingAmount(0).build();
 
 		when(depositRepository.findByMemberIdAndAuctionId(4L, 3L)).thenReturn(Optional.empty());
-		when(memberRepository.findById(4L)).thenReturn(Optional.of(mock(PaymentMember.class)));
-		when(walletRepository.findByMemberId(4L)).thenReturn(Optional.of(wallet));
+		given(paymentSupport.findMemberById(4L)).willReturn(mock(PaymentMember.class));
+		given(paymentSupport.findWalletByMemberId(4L)).willReturn(wallet);
 
 		// when & then
 		assertThatThrownBy(() -> paymentHoldDepositUseCase.holdDeposit(request))
@@ -107,7 +102,7 @@ class PaymentHoldDepositUseCaseTest {
 		// then
 		assertThat(response.depositId()).isEqualTo(100L);
 		assertThat(response.status()).isEqualTo("HOLD");
-		verify(walletRepository, never()).findByMemberId(anyLong());
+		verify(paymentSupport, never()).findWalletByMemberId(anyLong());
 		verify(depositRepository, never()).save(any());
 		verify(transactionRepository, never()).save(any());
 	}

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentRequestPaymentUseCaseTest.java
@@ -3,8 +3,6 @@ package com.bugzero.rarego.boundedContext.payment.app;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +16,6 @@ import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
 import com.bugzero.rarego.boundedContext.payment.domain.PaymentStatus;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
-import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
 import com.bugzero.rarego.boundedContext.payment.out.PaymentRepository;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
@@ -29,10 +26,10 @@ class PaymentRequestPaymentUseCaseTest {
 	private PaymentRequestPaymentUseCase useCase;
 
 	@Mock
-	private PaymentMemberRepository paymentMemberRepository;
+	private PaymentRepository paymentRepository;
 
 	@Mock
-	private PaymentRepository paymentRepository;
+	private PaymentSupport paymentSupport;
 
 	@Test
 	@DisplayName("예치금 결제 요청 성공 테스트")
@@ -46,8 +43,7 @@ class PaymentRequestPaymentUseCaseTest {
 		PaymentMember member = PaymentMember.builder().id(memberId).build();
 
 		// repository.findById 호출 시 가짜 멤버 리턴하도록 설정
-		given(paymentMemberRepository.findById(memberId))
-			.willReturn(Optional.of(member));
+		given(paymentSupport.findMemberById(memberId)).willReturn(member);
 
 		// when
 		PaymentRequestResponseDto response = useCase.requestPayment(memberId, requestDto);
@@ -78,8 +74,8 @@ class PaymentRequestPaymentUseCaseTest {
 		PaymentRequestDto requestDto = new PaymentRequestDto(amount);
 
 		// repository가 빈 값을 반환하도록 설정
-		given(paymentMemberRepository.findById(memberId))
-			.willReturn(Optional.empty());
+		given(paymentSupport.findMemberById(memberId))
+			.willThrow(new CustomException(ErrorType.MEMBER_NOT_FOUND));
 
 		// when & then
 		assertThatThrownBy(() -> useCase.requestPayment(memberId, requestDto))


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #56

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

- [ ] PaymentSupport로 단순 조회 코드 분리
- [ ] 테스트 코드 수정

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
단순 조회 코드를 PaymentSupport로 분리했습니다. 우진님은 구현에 참고해주세요.

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
5분
