### PR TITLE
[FIX/auction] AuctionOrder sellerId 추가

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleExpiredUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleExpiredUseCase.java
@@ -40,8 +40,7 @@ public class AuctionSettleExpiredUseCase {
                     Bid winningBid = support.findWinningBid(auction.getId());
                     details.add(AuctionAutoResponseDto.SettlementDetail.success(
                             auction.getId(),
-                            winningBid.getBidderId()
-                    ));
+                            winningBid.getBidderId()));
                     success++;
                 } else {
                     handleFail(auction);
@@ -64,9 +63,7 @@ public class AuctionSettleExpiredUseCase {
         eventPublisher.publishEvent(
                 new AuctionFailedEvent(
                         auction.getId(),
-                        auction.getProductId()
-                )
-        );
+                        auction.getProductId()));
     }
 
     private void handleSuccess(Auction auction) {
@@ -78,6 +75,7 @@ public class AuctionSettleExpiredUseCase {
         auctionOrderRepository.save(
                 AuctionOrder.builder()
                         .auctionId(auction.getId())
+                        .sellerId(auction.getSellerId())
                         .bidderId(winningBid.getBidderId())
                         .finalPrice(winningBid.getBidAmount())
                         .build()

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
@@ -77,6 +77,7 @@ public class AuctionSettleOneUseCase {
         auctionOrderRepository.save(
                 AuctionOrder.builder()
                         .auctionId(auction.getId())
+                        .sellerId(auction.getSellerId())
                         .bidderId(winningBid.getBidderId())
                         .finalPrice(winningBid.getBidAmount())
                         .build()

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Auction.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/Auction.java
@@ -21,6 +21,9 @@ public class Auction extends BaseIdAndTime {
     private Long productId;
 
     @Column(nullable = false)
+    private Long sellerId;
+
+    @Column(nullable = false)
     private LocalDateTime startTime;
 
     @Column(nullable = false)
@@ -40,8 +43,10 @@ public class Auction extends BaseIdAndTime {
 
     // 입찰 가격 갱신
     @Builder
-    public Auction(Long productId, LocalDateTime startTime, LocalDateTime endTime, int startPrice, int tickSize) {
+    public Auction(Long productId, Long sellerId, LocalDateTime startTime, LocalDateTime endTime, int startPrice,
+            int tickSize) {
         this.productId = productId;
+        this.sellerId = sellerId;
         this.startTime = startTime;
         this.endTime = endTime;
         this.startPrice = startPrice;

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/in/AuctionDataInit.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/in/AuctionDataInit.java
@@ -97,6 +97,7 @@ public class AuctionDataInit {
 
         Auction normalAuction = Auction.builder()
                 .productId(product1.getId())
+                .sellerId(product1.getSellerId())
                 .startTime(LocalDateTime.now())
                 .endTime(LocalDateTime.now().plusDays(3))
                 .startPrice(1_000_000)
@@ -111,7 +112,7 @@ public class AuctionDataInit {
 
         // 3-1. 종료 + 입찰 있음 (낙찰 대상)
         Product product2 = createProduct(seller.getId(), "테스트 상품 1", 10_000);
-        Auction auction1 = createAuction(product2.getId(), -2, -1, 10_000, 1_000);
+        Auction auction1 = createAuction(product2.getId(), product2.getSellerId(), -2, -1, 10_000, 1_000);
         auction1.forceStartForTest();
         auctionRepository.save(auction1);
         bidRepository.save(createBid(auction1.getId(), buyer.getId(), 15_000));
@@ -120,20 +121,20 @@ public class AuctionDataInit {
 
         // 3-2. 종료 + 입찰 없음 (유찰 대상)
         Product product3 = createProduct(seller.getId(), "테스트 상품 2", 20_000);
-        Auction auction2 = createAuction(product3.getId(), -2, 0, 20_000, 2_000);
+        Auction auction2 = createAuction(product3.getId(), product3.getSellerId(), -2, 0, 20_000, 2_000);
         auction2.forceStartForTest();
         auctionRepository.save(auction2);
 
         // 3-3. 종료 + 입찰 1건 (낙찰 대상)
         Product product4 = createProduct(seller.getId(), "테스트 상품 3", 30_000);
-        Auction auction3 = createAuction(product4.getId(), -3, 0, 30_000, 3_000);
+        Auction auction3 = createAuction(product4.getId(), product4.getSellerId(), -3, 0, 30_000, 3_000);
         auction3.forceStartForTest();
         auctionRepository.save(auction3);
         bidRepository.save(createBid(auction3.getId(), buyer.getId(), 35_000));
 
         // 3-4. 진행 중 + 1분 후 종료 (동적 스케줄링 테스트용)
         Product product5 = createProduct(seller.getId(), "테스트 상품 4", 40_000);
-        Auction auction4 = createAuction(product5.getId(), -1, 1, 40_000, 4_000);
+        Auction auction4 = createAuction(product5.getId(), product5.getSellerId(), -1, 1, 40_000, 4_000);
         auction4.forceStartForTest();
         auctionRepository.save(auction4);
         bidRepository.save(createBid(auction4.getId(), buyer.getId(), 45_000));
@@ -141,13 +142,11 @@ public class AuctionDataInit {
         eventPublisher.publishEvent(
                 new AuctionCreatedEvent(
                         auction4.getId(),
-                        auction4.getEndTime()
-                )
-        );
+                                auction4.getEndTime()));
 
         // 3-5. 진행 중 + 5분 후 종료 (동적 스케줄링 테스트용)
         Product product6 = createProduct(seller.getId(), "테스트 상품 5", 50_000);
-        Auction auction5 = createAuction(product6.getId(), -1, 5, 50_000, 5_000);
+        Auction auction5 = createAuction(product6.getId(), product6.getSellerId(), -1, 5, 50_000, 5_000);
         auction5.forceStartForTest();
         auctionRepository.save(auction5);
         bidRepository.save(createBid(auction5.getId(), buyer.getId(), 55_000));
@@ -155,9 +154,7 @@ public class AuctionDataInit {
         eventPublisher.publishEvent(
                 new AuctionCreatedEvent(
                         auction5.getId(),
-                        auction5.getEndTime()
-                )
-        );
+                                auction5.getEndTime()));
 
         log.info("=== 경매 테스트 데이터 초기화 완료 ===");
         log.info("- 정상 경매: 1건 (3일 후 종료)");
@@ -194,6 +191,7 @@ public class AuctionDataInit {
 
     private Auction createAuction(
             Long productId,
+            Long sellerId,
             int startHoursOffset,
             int endMinutesOffset,
             int startPrice,
@@ -202,6 +200,7 @@ public class AuctionDataInit {
         LocalDateTime now = LocalDateTime.now();
         return Auction.builder()
                 .productId(productId)
+                .sellerId(sellerId)
                 .startTime(now.plusHours(startHoursOffset))
                 .endTime(endMinutesOffset > 0
                         ? now.plusMinutes(endMinutesOffset)

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionCreateBidUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionCreateBidUseCaseTest.java
@@ -64,6 +64,7 @@ class AuctionCreateBidUseCaseTest {
 		// 2. 경매(Auction) Mock - 정상 진행 중 상태
 		Auction auction = Auction.builder()
 			.productId(PRODUCT_ID)
+			.sellerId(SELLER_ID)
 			.startPrice(5000)
 			.tickSize(1000)
 			.startTime(LocalDateTime.now().minusHours(1))
@@ -105,6 +106,7 @@ class AuctionCreateBidUseCaseTest {
 
 		Auction auction = Auction.builder()
 			.productId(PRODUCT_ID)
+			.sellerId(SELLER_ID)
 			.startTime(LocalDateTime.now().minusHours(1))
 			.endTime(LocalDateTime.now().plusHours(1))
 			.build();
@@ -141,6 +143,7 @@ class AuctionCreateBidUseCaseTest {
 
 		Auction auction = Auction.builder()
 			.productId(PRODUCT_ID)
+			.sellerId(SELLER_ID)
 			.startPrice(5000)
 			.tickSize(1000)
 			.startTime(LocalDateTime.now().minusHours(1))

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCaseTest.java
@@ -45,6 +45,7 @@ class AuctionSettleOneUseCaseTest {
     private Auction createAuction(Long id, AuctionStatus status, LocalDateTime endTime) {
         Auction auction = Auction.builder()
                 .productId(100L)
+                .sellerId(1L)
                 .startTime(LocalDateTime.now().minusHours(1))
                 .endTime(endTime)
                 .startPrice(10_000)


### PR DESCRIPTION
# 🐛 버그 수정 PR

## #️⃣ 연관된 이슈
close: #73 

## 📝 수정 요약

- 🚨 문제점
  - AuctionOrder 생성 시 sellerId가 누락되어 NOT NULL 제약 위반으로 서버 실행 불가 문제 발생

- 🔍 원인 분석
  - AuctionOrder 엔티티에 sellerId 필드가 추가 (nullable = false)
  - AuctionSettleOneUseCase.handleSuccess()와 AuctionSettleExpiredUseCase.handleSuccess()에서 AuctionOrder.builder() 호출 시 sellerId 미설정
 
- 💡 해결 방법
  - Auction 엔티티에 sellerId 필드 추가
  - 경매 생성 시 Product.sellerId를 Auction.sellerId에 복사
  - AuctionSettleXXXUseCase에서 auction.getSellerId()로 조회
  - Product의 sellerId와 중복되지만, 의도적인 비정규화를 통해 모듈 간 결합도 및 복잡도 낮춤

## 🛠️ PR 유형
- [X] 버그 수정
- [X] 테스트 리팩토링
- [X] 코드 리팩토링
- [X] 문서 수정 (ERD)

## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분
