### PR TITLE
[FEAT/auction] 낙찰자 미결제 타임아웃 처리(경매 취소/실패 확정)

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacade.java
@@ -1,22 +1,7 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionMember;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
-import com.bugzero.rarego.boundedContext.auction.domain.Bid;
+import com.bugzero.rarego.boundedContext.auction.domain.*;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionMemberRepository;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
@@ -28,15 +13,20 @@ import com.bugzero.rarego.global.response.ErrorType;
 import com.bugzero.rarego.global.response.PageDto;
 import com.bugzero.rarego.global.response.PagedResponseDto;
 import com.bugzero.rarego.global.response.SuccessResponseDto;
-import com.bugzero.rarego.shared.auction.dto.AuctionFilterType;
-import com.bugzero.rarego.shared.auction.dto.BidLogResponseDto;
-import com.bugzero.rarego.shared.auction.dto.BidResponseDto;
-import com.bugzero.rarego.shared.auction.dto.MyBidResponseDto;
-import com.bugzero.rarego.shared.auction.dto.MySaleResponseDto;
-
+import com.bugzero.rarego.shared.auction.dto.*;
 import lombok.RequiredArgsConstructor;
-
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -44,149 +34,127 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class AuctionFacade {
 
-	private final AuctionCreateBidUseCase auctionCreateBidUseCase;
-	private final BidRepository bidRepository;
-	private final AuctionMemberRepository auctionMemberRepository;
-	private final AuctionRepository auctionRepository;
-	private final ProductRepository productRepository;
-	private final AuctionOrderRepository auctionOrderRepository;
+    private final AuctionCreateBidUseCase auctionCreateBidUseCase;
+    private final AuctionProcessTimeoutUseCase auctionProcessTimeoutUseCase;
+    private final BidRepository bidRepository;
+    private final AuctionMemberRepository auctionMemberRepository;
+    private final AuctionRepository auctionRepository;
+    private final ProductRepository productRepository;
+    private final AuctionOrderRepository auctionOrderRepository;
 
-	@Transactional
-	public SuccessResponseDto<BidResponseDto> createBid(Long auctionId, Long memberId, int bidAmount) {
-		return auctionCreateBidUseCase.createBid(auctionId, memberId, bidAmount);
-	}
+    @Transactional
+    public SuccessResponseDto<BidResponseDto> createBid(Long auctionId, Long memberId, int bidAmount) {
+        return auctionCreateBidUseCase.createBid(auctionId, memberId, bidAmount);
+    }
 
-	// 경매 입찰 기록 조회
-	public PagedResponseDto<BidLogResponseDto> getBidLogs(Long auctionId, Pageable pageable) {
-		Page<Bid> bidPage = bidRepository.findAllByAuctionIdOrderByBidTimeDesc(auctionId, pageable);
+    // 경매 입찰 기록 조회
+    public PagedResponseDto<BidLogResponseDto> getBidLogs(Long auctionId, Pageable pageable) {
+        Page<Bid> bidPage = bidRepository.findAllByAuctionIdOrderByBidTimeDesc(auctionId, pageable);
 
-		// 1. 입찰자 정보 Map 생성 (Helper 사용)
-		Map<Long, String> bidderMap = getBidderPublicIdMap(bidPage.getContent());
+        Map<Long, String> bidderMap = getBidderPublicIdMap(bidPage.getContent());
 
-		// 2. DTO 변환
-		Page<BidLogResponseDto> dtoPage = bidPage.map(bid -> {
-			String publicId = bidderMap.get(bid.getBidderId());
-			if (publicId == null) {
-				log.warn("입찰자 정보 없음: bidderId={}", bid.getBidderId());
-				publicId = "unknown";
-			}
-			return BidLogResponseDto.from(bid, publicId);
-		});
+        Page<BidLogResponseDto> dtoPage = bidPage.map(bid -> {
+            String publicId = bidderMap.get(bid.getBidderId());
+            if (publicId == null) {
+                log.warn("입찰자 정보 없음: bidderId={}", bid.getBidderId());
+                publicId = "unknown";
+            }
+            return BidLogResponseDto.from(bid, publicId);
+        });
 
+        return new PagedResponseDto<>(dtoPage.getContent(), PageDto.from(dtoPage));
+    }
 
-		return new PagedResponseDto<>(dtoPage.getContent(), PageDto.from(dtoPage));
-	}
+    // 나의 입찰 내역 조회
+    public PagedResponseDto<MyBidResponseDto> getMyBids(Long memberId, AuctionStatus status, Pageable pageable) {
+        Page<Bid> bidPage = bidRepository.findMyBids(memberId, status, pageable);
+        List<Bid> bids = bidPage.getContent();
 
-	// 나의 입찰 내역 조회
-	public PagedResponseDto<MyBidResponseDto> getMyBids(Long memberId, AuctionStatus status, Pageable pageable) {
-		// 1. Bid 목록 조회
-		Page<Bid> bidPage = bidRepository.findMyBids(memberId, status, pageable);
-		List<Bid> bids = bidPage.getContent();
+        Map<Long, Auction> auctionMap = getAuctionMap(bids);
 
-		// 2. Auction Map 생성 (Helper 메서드 재사용)
-		Map<Long, Auction> auctionMap = getAuctionMap(bids);
+        Page<MyBidResponseDto> dtoPage = bidPage.map(bid -> {
+            Auction auction = auctionMap.get(bid.getAuctionId());
+            if (auction == null) {
+                throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
+            }
+            return MyBidResponseDto.from(bid, auction);
+        });
 
-		// 3. DTO 변환 (상품명 매핑 과정 생략)
-		Page<MyBidResponseDto> dtoPage = bidPage.map(bid -> {
-			Auction auction = auctionMap.get(bid.getAuctionId());
+        return new PagedResponseDto<>(dtoPage.getContent(), PageDto.from(dtoPage));
+    }
 
-			// 데이터 무결성 체크 (Auction이 없는 경우 예외 발생)
-			if (auction == null) {
-				throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
-			}
+    // 나의 판매 내역 조회
+    public PagedResponseDto<MySaleResponseDto> getMySales(Long memberId, AuctionFilterType auctionFilterType, Pageable pageable) {
+        List<Long> myProductIds = productRepository.findAllIdsBySellerId(memberId);
 
-			return MyBidResponseDto.from(bid, auction);
-		});
+        Page<Auction> auctionPage = fetchAuctionsByFilter(myProductIds, auctionFilterType, pageable);
+        List<Auction> auctions = auctionPage.getContent();
 
-		return new PagedResponseDto<>(dtoPage.getContent(), PageDto.from(dtoPage));
-	}
+        if (auctions.isEmpty()) {
+            return new PagedResponseDto<>(List.of(), PageDto.from(auctionPage));
+        }
 
-	public PagedResponseDto<MySaleResponseDto> getMySales(Long memberId, AuctionFilterType auctionFilterType, Pageable pageable) {
-		// 상품 Id 목록 조회
-		List<Long> myProductIds = productRepository.findAllIdsBySellerId(memberId);
+        Set<Long> productIds = auctions.stream().map(Auction::getProductId).collect(Collectors.toSet());
+        Set<Long> auctionIds = auctions.stream().map(Auction::getId).collect(Collectors.toSet());
 
-		// 경매 목록 조회
-		Page<Auction> auctionPage = fetchAuctionsByFilter(myProductIds, auctionFilterType, pageable);
-		List<Auction> auctions = auctionPage.getContent();
+        Map<Long, Product> productMap = productRepository.findAllByIdIn(productIds).stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
 
-		if (auctions.isEmpty()) {
-			return new PagedResponseDto<>(List.of(), PageDto.from(auctionPage));
-		}
+        Map<Long, AuctionOrder> orderMap = auctionOrderRepository.findAllByAuctionIdIn(auctionIds).stream()
+                .collect(Collectors.toMap(AuctionOrder::getAuctionId, Function.identity()));
 
-		// 연관 데이터 일괄적으로 조회
-		Set<Long> productIds = auctions.stream().map(Auction::getProductId).collect(Collectors.toSet());
-		Set<Long> auctionIds = auctions.stream().map(Auction::getId).collect(Collectors.toSet());
+        Map<Long, Integer> bidCountMap = bidRepository.countByAuctionIdIn(auctionIds).stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> ((Long) row[1]).intValue()));
 
-		// 상품 정보
-		Map<Long, Product> productMap = productRepository.findAllByIdIn(productIds).stream()
-			.collect(Collectors.toMap(Product::getId, p -> p));
+        List<MySaleResponseDto> dtoList = auctions.stream()
+                .map(auction -> MySaleResponseDto.from(
+                        auction,
+                        productMap.get(auction.getProductId()),
+                        orderMap.get(auction.getId()),
+                        bidCountMap.getOrDefault(auction.getId(), 0)
+                ))
+                .toList();
 
-		// 주문 정보 (거래 상태)
-		Map<Long, AuctionOrder> orderMap = auctionOrderRepository.findAllByAuctionIdIn(auctionIds).stream()
-			.collect(Collectors.toMap(AuctionOrder::getAuctionId, Function.identity()));
+        return new PagedResponseDto<>(dtoList, PageDto.from(auctionPage));
+    }
 
-		// 입찰 횟수 정보
-		Map<Long, Integer> bidCountMap = bidRepository.countByAuctionIdIn(auctionIds).stream()
-			.collect(Collectors.toMap(row -> (Long) row[0], row -> ((Long) row[1]).intValue()));
+    /**
+     * 결제 타임아웃 처리
+     */
+    @Transactional
+    public AuctionPaymentTimeoutResponse processPaymentTimeout() {
+        return auctionProcessTimeoutUseCase.execute();
+    }
 
-		// DTO 변환
-		List<MySaleResponseDto> dtoList = auctions.stream()
-			.map(auction -> MySaleResponseDto.from(
-				auction,
-				productMap.get(auction.getProductId()),
-				orderMap.get(auction.getId()),
-				bidCountMap.getOrDefault(auction.getId(), 0)
-			))
-			.toList();
+    // =========================================================================
+    //  Helper Methods
+    // =========================================================================
 
-		return new PagedResponseDto<>(dtoList, PageDto.from(auctionPage));
-	}
+    private Map<Long, String> getBidderPublicIdMap(List<Bid> bids) {
+        if (bids.isEmpty()) return Collections.emptyMap();
+        Set<Long> bidderIds = bids.stream().map(Bid::getBidderId).collect(Collectors.toSet());
+        return auctionMemberRepository.findAllById(bidderIds).stream()
+                .collect(Collectors.toMap(AuctionMember::getId, AuctionMember::getPublicId));
+    }
 
+    private Map<Long, Auction> getAuctionMap(List<Bid> bids) {
+        if (bids.isEmpty()) return Collections.emptyMap();
+        Set<Long> auctionIds = bids.stream().map(Bid::getAuctionId).collect(Collectors.toSet());
+        return auctionRepository.findAllById(auctionIds).stream()
+                .collect(Collectors.toMap(Auction::getId, Function.identity()));
+    }
 
-	// =========================================================================
-	//  Helper Methods (Private) - 복잡한 조회/매핑 로직을 아래로 숨김
-	// =========================================================================
-
-	// 입찰 목록에서 입찰자 ID를 추출하여 PublicId Map 반환
-	private Map<Long, String> getBidderPublicIdMap(List<Bid> bids) {
-		if (bids.isEmpty()) return Collections.emptyMap();
-
-		Set<Long> bidderIds = bids.stream()
-			.map(Bid::getBidderId)
-			.collect(Collectors.toSet());
-
-		return auctionMemberRepository.findAllById(bidderIds).stream()
-			.collect(Collectors.toMap(AuctionMember::getId, AuctionMember::getPublicId));
-	}
-
-	// 입찰 목록에서 경매 ID를 추출하여 Auction Map 반환
-	private Map<Long, Auction> getAuctionMap(List<Bid> bids) {
-		if (bids.isEmpty()) return Collections.emptyMap();
-
-		Set<Long> auctionIds = bids.stream()
-			.map(Bid::getAuctionId)
-			.collect(Collectors.toSet());
-
-		return auctionRepository.findAllById(auctionIds).stream()
-			.collect(Collectors.toMap(Auction::getId, Function.identity()));
-	}
-
-	private Page<Auction> fetchAuctionsByFilter(List<Long> productIds, AuctionFilterType filter, Pageable pageable) {
-		switch (filter) {
-			// 진행 중 & 진행 예정
-			case ONGOING:
-				return auctionRepository.findAllByProductIdInAndStatusIn(productIds,
-					List.of(AuctionStatus.SCHEDULED, AuctionStatus.IN_PROGRESS), pageable);
-			// 판매 완료 (정상 거래)
-			case COMPLETED:
-				return auctionRepository.findAllByProductIdInAndStatusIn(productIds,
-					List.of(AuctionStatus.ENDED), pageable);
-			// 유찰 등 조치 필요
-			case ACTION_REQUIRED:
-				return auctionRepository.findAllByProductIdInAndStatusIn(productIds,
-					List.of(AuctionStatus.ENDED), pageable);
-			default:
-				return auctionRepository.findAllByProductIdIn(productIds, pageable);
-		}
-	}
+    private Page<Auction> fetchAuctionsByFilter(List<Long> productIds, AuctionFilterType filter, Pageable pageable) {
+        switch (filter) {
+            case ONGOING:
+                return auctionRepository.findAllByProductIdInAndStatusIn(productIds,
+                        List.of(AuctionStatus.SCHEDULED, AuctionStatus.IN_PROGRESS), pageable);
+            case COMPLETED:
+            case ACTION_REQUIRED:
+                return auctionRepository.findAllByProductIdInAndStatusIn(productIds,
+                        List.of(AuctionStatus.ENDED), pageable);
+            default:
+                return auctionRepository.findAllByProductIdIn(productIds, pageable);
+        }
+    }
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacade.java
@@ -1,26 +1,13 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.bugzero.rarego.boundedContext.auction.domain.Auction;
 import com.bugzero.rarego.boundedContext.auction.domain.AuctionMember;
 import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
 import com.bugzero.rarego.boundedContext.auction.domain.Bid;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionMemberRepository;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
 import com.bugzero.rarego.boundedContext.auction.out.BidRepository;
-import com.bugzero.rarego.boundedContext.product.domain.Product;
-import com.bugzero.rarego.boundedContext.product.out.ProductRepository;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
 import com.bugzero.rarego.global.response.PageDto;
@@ -29,10 +16,19 @@ import com.bugzero.rarego.global.response.SuccessResponseDto;
 import com.bugzero.rarego.shared.auction.dto.BidLogResponseDto;
 import com.bugzero.rarego.shared.auction.dto.BidResponseDto;
 import com.bugzero.rarego.shared.auction.dto.MyBidResponseDto;
-
 import lombok.RequiredArgsConstructor;
-
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -40,89 +36,96 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class AuctionFacade {
 
-	private final AuctionCreateBidUseCase auctionCreateBidUseCase;
-	private final BidRepository bidRepository;
-	private final AuctionMemberRepository auctionMemberRepository;
-	private final AuctionRepository auctionRepository;
-	private final ProductRepository productRepository;
+    private final AuctionCreateBidUseCase auctionCreateBidUseCase;
+    private final BidRepository bidRepository;
+    private final AuctionMemberRepository auctionMemberRepository;
+    private final AuctionRepository auctionRepository;
+    private final AuctionProcessTimeoutUseCase auctionProcessTimeoutUseCase;
 
-	@Transactional
-	public SuccessResponseDto<BidResponseDto> createBid(Long auctionId, Long memberId, int bidAmount) {
-		return auctionCreateBidUseCase.createBid(auctionId, memberId, bidAmount);
-	}
+    @Transactional
+    public SuccessResponseDto<BidResponseDto> createBid(Long auctionId, Long memberId, int bidAmount) {
+        return auctionCreateBidUseCase.createBid(auctionId, memberId, bidAmount);
+    }
 
-	// 경매 입찰 기록 조회
-	public PagedResponseDto<BidLogResponseDto> getBidLogs(Long auctionId, Pageable pageable) {
-		Page<Bid> bidPage = bidRepository.findAllByAuctionIdOrderByBidTimeDesc(auctionId, pageable);
+    // 경매 입찰 기록 조회
+    public PagedResponseDto<BidLogResponseDto> getBidLogs(Long auctionId, Pageable pageable) {
+        Page<Bid> bidPage = bidRepository.findAllByAuctionIdOrderByBidTimeDesc(auctionId, pageable);
 
-		// 1. 입찰자 정보 Map 생성 (Helper 사용)
-		Map<Long, String> bidderMap = getBidderPublicIdMap(bidPage.getContent());
+        // 1. 입찰자 정보 Map 생성 (Helper 사용)
+        Map<Long, String> bidderMap = getBidderPublicIdMap(bidPage.getContent());
 
-		// 2. DTO 변환
-		Page<BidLogResponseDto> dtoPage = bidPage.map(bid -> {
-			String publicId = bidderMap.get(bid.getBidderId());
-			if (publicId == null) {
-				log.warn("입찰자 정보 없음: bidderId={}", bid.getBidderId());
-				publicId = "unknown";
-			}
-			return BidLogResponseDto.from(bid, publicId);
-		});
-
-
-		return new PagedResponseDto<>(dtoPage.getContent(), PageDto.from(dtoPage));
-	}
-
-	// 나의 입찰 내역 조회
-	public PagedResponseDto<MyBidResponseDto> getMyBids(Long memberId, AuctionStatus status, Pageable pageable) {
-		// 1. Bid 목록 조회
-		Page<Bid> bidPage = bidRepository.findMyBids(memberId, status, pageable);
-		List<Bid> bids = bidPage.getContent();
-
-		// 2. Auction Map 생성 (Helper 메서드 재사용)
-		Map<Long, Auction> auctionMap = getAuctionMap(bids);
-
-		// 3. DTO 변환 (상품명 매핑 과정 생략)
-		Page<MyBidResponseDto> dtoPage = bidPage.map(bid -> {
-			Auction auction = auctionMap.get(bid.getAuctionId());
-
-			// 데이터 무결성 체크 (Auction이 없는 경우 예외 발생)
-			if (auction == null) {
-				throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
-			}
-
-			return MyBidResponseDto.from(bid, auction);
-		});
-
-		return new PagedResponseDto<>(dtoPage.getContent(), PageDto.from(dtoPage));
-	}
+        // 2. DTO 변환
+        Page<BidLogResponseDto> dtoPage = bidPage.map(bid -> {
+            String publicId = bidderMap.get(bid.getBidderId());
+            if (publicId == null) {
+                log.warn("입찰자 정보 없음: bidderId={}", bid.getBidderId());
+                publicId = "unknown";
+            }
+            return BidLogResponseDto.from(bid, publicId);
+        });
 
 
-	// =========================================================================
-	//  Helper Methods (Private) - 복잡한 조회/매핑 로직을 아래로 숨김
-	// =========================================================================
+        return new PagedResponseDto<>(dtoPage.getContent(), PageDto.from(dtoPage));
+    }
 
-	// 입찰 목록에서 입찰자 ID를 추출하여 PublicId Map 반환
-	private Map<Long, String> getBidderPublicIdMap(List<Bid> bids) {
-		if (bids.isEmpty()) return Collections.emptyMap();
+    // 나의 입찰 내역 조회
+    public PagedResponseDto<MyBidResponseDto> getMyBids(Long memberId, AuctionStatus status, Pageable pageable) {
+        // 1. Bid 목록 조회
+        Page<Bid> bidPage = bidRepository.findMyBids(memberId, status, pageable);
+        List<Bid> bids = bidPage.getContent();
 
-		Set<Long> bidderIds = bids.stream()
-			.map(Bid::getBidderId)
-			.collect(Collectors.toSet());
+        // 2. Auction Map 생성 (Helper 메서드 재사용)
+        Map<Long, Auction> auctionMap = getAuctionMap(bids);
 
-		return auctionMemberRepository.findAllById(bidderIds).stream()
-			.collect(Collectors.toMap(AuctionMember::getId, AuctionMember::getPublicId));
-	}
+        // 3. DTO 변환 (상품명 매핑 과정 생략)
+        Page<MyBidResponseDto> dtoPage = bidPage.map(bid -> {
+            Auction auction = auctionMap.get(bid.getAuctionId());
 
-	// 입찰 목록에서 경매 ID를 추출하여 Auction Map 반환
-	private Map<Long, Auction> getAuctionMap(List<Bid> bids) {
-		if (bids.isEmpty()) return Collections.emptyMap();
+            // 데이터 무결성 체크 (Auction이 없는 경우 예외 발생)
+            if (auction == null) {
+                throw new CustomException(ErrorType.AUCTION_NOT_FOUND);
+            }
 
-		Set<Long> auctionIds = bids.stream()
-			.map(Bid::getAuctionId)
-			.collect(Collectors.toSet());
+            return MyBidResponseDto.from(bid, auction);
+        });
 
-		return auctionRepository.findAllById(auctionIds).stream()
-			.collect(Collectors.toMap(Auction::getId, Function.identity()));
-	}
+        return new PagedResponseDto<>(dtoPage.getContent(), PageDto.from(dtoPage));
+    }
+
+    /**
+     * 결제 타임아웃 처리 (배치)
+     */
+    @Transactional
+    public AuctionPaymentTimeoutResponse processPaymentTimeout() {
+        return auctionProcessTimeoutUseCase.execute();
+    }
+
+    // =========================================================================
+    //  Helper Methods (Private) - 복잡한 조회/매핑 로직을 아래로 숨김
+    // =========================================================================
+
+    // 입찰 목록에서 입찰자 ID를 추출하여 PublicId Map 반환
+    private Map<Long, String> getBidderPublicIdMap(List<Bid> bids) {
+        if (bids.isEmpty()) return Collections.emptyMap();
+
+        Set<Long> bidderIds = bids.stream()
+                .map(Bid::getBidderId)
+                .collect(Collectors.toSet());
+
+        return auctionMemberRepository.findAllById(bidderIds).stream()
+                .collect(Collectors.toMap(AuctionMember::getId, AuctionMember::getPublicId));
+    }
+
+    // 입찰 목록에서 경매 ID를 추출하여 Auction Map 반환
+    private Map<Long, Auction> getAuctionMap(List<Bid> bids) {
+        if (bids.isEmpty()) return Collections.emptyMap();
+
+        Set<Long> auctionIds = bids.stream()
+                .map(Bid::getAuctionId)
+                .collect(Collectors.toSet());
+
+        return auctionRepository.findAllById(auctionIds).stream()
+                .collect(Collectors.toMap(Auction::getId, Function.identity()));
+    }
 
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionProcessTimeoutUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionProcessTimeoutUseCase.java
@@ -1,0 +1,93 @@
+package com.bugzero.rarego.boundedContext.auction.app;
+
+import com.bugzero.rarego.boundedContext.auction.domain.Auction;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrderStatus;
+import com.bugzero.rarego.boundedContext.auction.domain.event.AuctionPaymentTimeoutEvent;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse.TimeoutDetail;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuctionProcessTimeoutUseCase {
+
+    private final AuctionOrderRepository orderRepository;
+    private final AuctionRepository auctionRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    private static final int TIMEOUT_HOURS = 24;
+
+    @Transactional
+    public AuctionPaymentTimeoutResponse execute() {
+        LocalDateTime requestTime = LocalDateTime.now();
+        LocalDateTime cutoffTime = requestTime.minusHours(TIMEOUT_HOURS);
+
+        List<AuctionOrder> timedOutOrders = orderRepository
+                .findByStatusAndCreatedAtBefore(AuctionOrderStatus.PROCESSING, cutoffTime);
+
+        log.info("타임아웃 대상 주문 수: {}", timedOutOrders.size());
+
+        List<TimeoutDetail> details = new ArrayList<>();
+
+        for (AuctionOrder order : timedOutOrders) {
+            try {
+                TimeoutDetail detail = processTimeoutOrder(order);
+                details.add(detail);
+            } catch (Exception e) {
+                log.error("주문 {} 타임아웃 처리 실패 - 이유: {}", order.getId(), e.getMessage());
+            }
+        }
+
+        return new AuctionPaymentTimeoutResponse(
+                requestTime,
+                details.size(),
+                details
+        );
+    }
+
+    private TimeoutDetail processTimeoutOrder(AuctionOrder order) {
+        order.timeout();
+
+        Auction auction = auctionRepository.findById(order.getAuctionId())
+                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
+
+        int penaltyAmount = mockForfeitDeposit(order.getBidderId(), order.getAuctionId());
+
+        eventPublisher.publishEvent(new AuctionPaymentTimeoutEvent(
+                order.getAuctionId(),
+                order.getBidderId(),
+                auction.getSellerId(),
+                penaltyAmount
+        ));
+
+        log.info("타임아웃 처리 완료 - orderId: {}, auctionId: {}, bidderId: {}, penalty: {}",
+                order.getId(), order.getAuctionId(), order.getBidderId(), penaltyAmount);
+
+        return new TimeoutDetail(
+                order.getId(),
+                order.getAuctionId(),
+                order.getBidderId(),
+                penaltyAmount,
+                AuctionOrderStatus.FAILED
+        );
+    }
+
+    private int mockForfeitDeposit(Long buyerId, Long auctionId) {
+        log.warn("[MOCK] 보증금 몰수 처리 - buyerId: {}, auctionId: {} (실제 구현 필요)", buyerId, auctionId);
+        return 0;
+    }
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionProcessTimeoutUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionProcessTimeoutUseCase.java
@@ -1,6 +1,5 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
-import com.bugzero.rarego.boundedContext.auction.domain.Auction;
 import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
 import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrderStatus;
 import com.bugzero.rarego.boundedContext.auction.domain.event.AuctionPaymentTimeoutEvent;
@@ -8,8 +7,6 @@ import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutRes
 import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse.TimeoutDetail;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
-import com.bugzero.rarego.global.exception.CustomException;
-import com.bugzero.rarego.global.response.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -62,15 +59,12 @@ public class AuctionProcessTimeoutUseCase {
     private TimeoutDetail processTimeoutOrder(AuctionOrder order) {
         order.timeout();
 
-        Auction auction = auctionRepository.findById(order.getAuctionId())
-                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
-
         int penaltyAmount = mockForfeitDeposit(order.getBidderId(), order.getAuctionId());
 
         eventPublisher.publishEvent(new AuctionPaymentTimeoutEvent(
                 order.getAuctionId(),
                 order.getBidderId(),
-                auction.getSellerId(),
+                order.getSellerId(),
                 penaltyAmount
         ));
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrder.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/AuctionOrder.java
@@ -3,12 +3,7 @@ package com.bugzero.rarego.boundedContext.auction.domain;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
 import com.bugzero.rarego.global.response.ErrorType;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,36 +15,43 @@ import lombok.NoArgsConstructor;
 @Getter
 public class AuctionOrder extends BaseIdAndTime {
 
-	@Column(nullable = false)
-	private Long auctionId;
+    @Column(nullable = false)
+    private Long auctionId;
 
-	@Column(nullable = false)
-	private Long sellerId;
+    @Column(nullable = false)
+    private Long sellerId;
 
-	@Column(nullable = false)
-	private Long bidderId;
+    @Column(nullable = false)
+    private Long bidderId;
 
-	@Column(nullable = false)
-	private int finalPrice;
+    @Column(nullable = false)
+    private int finalPrice;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
-	private AuctionOrderStatus status;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuctionOrderStatus status;
 
-	@Builder
-	public AuctionOrder(Long auctionId, Long sellerId, Long bidderId, Integer finalPrice) {
-		this.auctionId = auctionId;
-		this.sellerId = sellerId;
-		this.bidderId = bidderId;
-		this.finalPrice = finalPrice;
-		// 초기 상태는 결제 진행중
-		this.status = AuctionOrderStatus.PROCESSING;
-	}
+    @Builder
+    public AuctionOrder(Long auctionId, Long sellerId, Long bidderId, Integer finalPrice) {
+        this.auctionId = auctionId;
+        this.sellerId = sellerId;
+        this.bidderId = bidderId;
+        this.finalPrice = finalPrice;
+        // 초기 상태는 결제 진행중
+        this.status = AuctionOrderStatus.PROCESSING;
+    }
 
-	public void complete() {
-		if (this.status != AuctionOrderStatus.PROCESSING) {
-			throw new CustomException(ErrorType.INVALID_ORDER_STATUS);
-		}
-		this.status = AuctionOrderStatus.SUCCESS;
-	}
+    public void complete() {
+        if (this.status != AuctionOrderStatus.PROCESSING) {
+            throw new CustomException(ErrorType.INVALID_ORDER_STATUS);
+        }
+        this.status = AuctionOrderStatus.SUCCESS;
+    }
+
+    public void timeout() {
+        if (this.status != AuctionOrderStatus.PROCESSING) {
+            throw new CustomException(ErrorType.INVALID_ORDER_STATUS);
+        }
+        this.status = AuctionOrderStatus.FAILED;
+    }
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/event/AuctionPaymentTimeoutEvent.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/domain/event/AuctionPaymentTimeoutEvent.java
@@ -1,0 +1,9 @@
+package com.bugzero.rarego.boundedContext.auction.domain.event;
+
+public record AuctionPaymentTimeoutEvent(
+        Long auctionId,
+        Long buyerId,
+        Long sellerId,
+        int penaltyAmount
+) {
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/in/InternalAuctionController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/in/InternalAuctionController.java
@@ -1,14 +1,16 @@
 package com.bugzero.rarego.boundedContext.auction.in;
 
+import com.bugzero.rarego.boundedContext.auction.app.AuctionFacade;
 import com.bugzero.rarego.boundedContext.auction.app.AuctionSettleAuctionFacade;
 import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionAutoSettleResponseDto;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
 import com.bugzero.rarego.global.response.SuccessResponseDto;
 import com.bugzero.rarego.global.response.SuccessType;
-
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,14 +20,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Tag(name = "Internal - Auction", description = "내부 경매 API (시스템 전용)")
 @Hidden
+@Slf4j
 public class InternalAuctionController {
 
     private final AuctionSettleAuctionFacade facade;
+    private final AuctionFacade auctionFacade;
 
     @Operation(summary = "경매 정산", description = "종료된 경매를 정산합니다")
     @PostMapping("/settle")
     public SuccessResponseDto<AuctionAutoSettleResponseDto> settle() {
         return SuccessResponseDto.from(SuccessType.OK, facade.settle());
+    }
+
+    @Operation(summary = "낙찰 결제 타임아웃 처리",
+            description = "24시간 내 미결제 주문을 취소하고 보증금을 몰수합니다")
+    @PostMapping("/timeout")
+    public SuccessResponseDto<AuctionPaymentTimeoutResponse> processPaymentTimeout() {
+        return SuccessResponseDto.from(SuccessType.OK, auctionFacade.processPaymentTimeout());
     }
 }
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/in/dto/AuctionPaymentTimeoutResponse.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/in/dto/AuctionPaymentTimeoutResponse.java
@@ -1,0 +1,21 @@
+package com.bugzero.rarego.boundedContext.auction.in.dto;
+
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrderStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AuctionPaymentTimeoutResponse(
+        LocalDateTime requestTime,
+        int processedCount,
+        List<TimeoutDetail> details
+) {
+    public record TimeoutDetail(
+            Long orderId,
+            Long auctionId,
+            Long buyerId,
+            int penaltyAmount,
+            AuctionOrderStatus status
+    ) {
+    }
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/out/AuctionOrderRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/out/AuctionOrderRepository.java
@@ -1,8 +1,10 @@
 package com.bugzero.rarego.boundedContext.auction.out;
 
 import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +15,6 @@ public interface AuctionOrderRepository extends JpaRepository<AuctionOrder, Long
 
     // 경매 ID 목록으로 주문 정보 조회
     List<AuctionOrder> findAllByAuctionIdIn(Collection<Long> auctionIds);
+
+    List<AuctionOrder> findByStatusAndCreatedAtBefore(AuctionOrderStatus status, LocalDateTime cutoffTime);
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacadeTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacadeTest.java
@@ -131,6 +131,7 @@ class AuctionFacadeTest {
                 .startPrice(10000)
                 .startTime(LocalDateTime.now())
                 .endTime(LocalDateTime.now().plusDays(1))
+                .durationDays(3)
                 .build();
         ReflectionTestUtils.setField(auction, "id", auctionId);
         auction.startAuction();

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacadeTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacadeTest.java
@@ -1,15 +1,15 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
+import com.bugzero.rarego.boundedContext.auction.domain.*;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionMemberRepository;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
+import com.bugzero.rarego.boundedContext.auction.out.BidRepository;
+import com.bugzero.rarego.global.response.PagedResponseDto;
+import com.bugzero.rarego.shared.auction.dto.BidLogResponseDto;
+import com.bugzero.rarego.shared.auction.dto.MyBidResponseDto;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,116 +20,192 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionMember;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
-import com.bugzero.rarego.boundedContext.auction.domain.Bid;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionMemberRepository;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
-import com.bugzero.rarego.boundedContext.auction.out.BidRepository;
-import com.bugzero.rarego.global.response.PagedResponseDto;
-import com.bugzero.rarego.shared.auction.dto.BidLogResponseDto;
-import com.bugzero.rarego.shared.auction.dto.MyBidResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionFacadeTest {
 
-	@InjectMocks
-	private AuctionFacade auctionFacade;
+    @InjectMocks
+    private AuctionFacade auctionFacade;
 
-	@Mock
-	private BidRepository bidRepository;
-	@Mock
-	private AuctionMemberRepository auctionMemberRepository; // ID 조회를 위해 필요
-	@Mock
-	private AuctionRepository auctionRepository; // ID 조회를 위해 필요
-	@Mock
-	private AuctionCreateBidUseCase auctionCreateBidUseCase;
+    @Mock
+    private BidRepository bidRepository;
+    @Mock
+    private AuctionMemberRepository auctionMemberRepository; // ID 조회를 위해 필요
+    @Mock
+    private AuctionRepository auctionRepository; // ID 조회를 위해 필요
+    @Mock
+    private AuctionCreateBidUseCase auctionCreateBidUseCase;
+    @Mock
+    private AuctionProcessTimeoutUseCase auctionProcessTimeoutUseCase;
 
-	@Test
-	@DisplayName("경매 입찰 기록 조회: 닉네임 매핑 확인")
-	void getBidLogs_Success() {
-		// given
-		Long auctionId = 1L;
-		Long bidderId = 100L;
-		Pageable pageable = PageRequest.of(0, 10);
 
-		// Bid 데이터 (ID만 가짐)
-		Bid bid = Bid.builder()
-			.auctionId(auctionId)
-			.bidderId(bidderId)
-			.bidAmount(50000)
-			.build();
-		ReflectionTestUtils.setField(bid, "id", 1L);
+    @Test
+    @DisplayName("경매 입찰 기록 조회: 닉네임 매핑 확인")
+    void getBidLogs_Success() {
+        // given
+        Long auctionId = 1L;
+        Long bidderId = 100L;
+        Pageable pageable = PageRequest.of(0, 10);
 
-		// Member 데이터 (닉네임용)
-		AuctionMember bidder = AuctionMember.builder().publicId("user_masked").build();
-		ReflectionTestUtils.setField(bidder, "id", bidderId);
+        // Bid 데이터 (ID만 가짐)
+        Bid bid = Bid.builder()
+                .auctionId(auctionId)
+                .bidderId(bidderId)
+                .bidAmount(50000)
+                .build();
+        ReflectionTestUtils.setField(bid, "id", 1L);
 
-		// Mocking
-		given(bidRepository.findAllByAuctionIdOrderByBidTimeDesc(eq(auctionId), any(Pageable.class)))
-			.willReturn(new PageImpl<>(List.of(bid)));
+        // Member 데이터 (닉네임용)
+        AuctionMember bidder = AuctionMember.builder().publicId("user_masked").build();
+        ReflectionTestUtils.setField(bidder, "id", bidderId);
 
-		// Facade가 ID로 Member를 조회함
-		given(auctionMemberRepository.findAllById(anySet())).willReturn(List.of(bidder));
+        // Mocking
+        given(bidRepository.findAllByAuctionIdOrderByBidTimeDesc(eq(auctionId), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(bid)));
 
-		// when
-		PagedResponseDto<BidLogResponseDto> result = auctionFacade.getBidLogs(auctionId, pageable);
+        // Facade가 ID로 Member를 조회함
+        given(auctionMemberRepository.findAllById(anySet())).willReturn(List.of(bidder));
 
-		// then
-		assertThat(result.data()).hasSize(1);
-		assertThat(result.data().get(0).publicId()).isEqualTo("user_masked");
-		assertThat(result.data().get(0).bidAmount()).isEqualTo(50000);
-	}
+        // when
+        PagedResponseDto<BidLogResponseDto> result = auctionFacade.getBidLogs(auctionId, pageable);
 
-	@Test
-	@DisplayName("나의 입찰 내역 조회: Auction 정보 매핑 확인 (productName 제외)")
-	void getMyBids_Success() {
-		// given
-		Long memberId = 100L;
-		Long auctionId = 10L;
-		Pageable pageable = PageRequest.of(0, 10);
+        // then
+        assertThat(result.data()).hasSize(1);
+        assertThat(result.data().get(0).publicId()).isEqualTo("user_masked");
+        assertThat(result.data().get(0).bidAmount()).isEqualTo(50000);
+    }
 
-		// Auction 데이터
-		Auction auction = Auction.builder()
-			.productId(50L)
-			.startPrice(10000)
-			.startTime(LocalDateTime.now())
-			.endTime(LocalDateTime.now().plusDays(1))
-			.build();
-		ReflectionTestUtils.setField(auction, "id", auctionId);
+    @Test
+    @DisplayName("나의 입찰 내역 조회: Auction 정보 매핑 확인 (productName 제외)")
+    void getMyBids_Success() {
+        // given
+        Long memberId = 100L;
+        Long auctionId = 10L;
+        Pageable pageable = PageRequest.of(0, 10);
 
-		auction.startAuction(); // 상태: IN_PROGRESS
+        // Auction 데이터
+        Auction auction = Auction.builder()
+                .productId(50L)
+                .startPrice(10000)
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusDays(1))
+                .build();
+        ReflectionTestUtils.setField(auction, "id", auctionId);
 
-		// [추가] currentPrice가 null이면 DTO 변환 시 NPE 발생하므로 값 설정 필수!
-		auction.updateCurrentPrice(15000);
+        auction.startAuction(); // 상태: IN_PROGRESS
 
-		// Bid 데이터
-		Bid bid = Bid.builder()
-			.auctionId(auctionId)
-			.bidderId(memberId)
-			.bidAmount(15000)
-			.build();
-		ReflectionTestUtils.setField(bid, "id", 1L);
+        // [추가] currentPrice가 null이면 DTO 변환 시 NPE 발생하므로 값 설정 필수!
+        auction.updateCurrentPrice(15000);
 
-		// Mocking
-		given(bidRepository.findMyBids(eq(memberId), any(), any(Pageable.class)))
-			.willReturn(new PageImpl<>(List.of(bid)));
+        // Bid 데이터
+        Bid bid = Bid.builder()
+                .auctionId(auctionId)
+                .bidderId(memberId)
+                .bidAmount(15000)
+                .build();
+        ReflectionTestUtils.setField(bid, "id", 1L);
 
-		// Facade가 ID로 Auction을 조회함
-		given(auctionRepository.findAllById(anySet())).willReturn(List.of(auction));
+        // Mocking
+        given(bidRepository.findMyBids(eq(memberId), any(), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(bid)));
 
-		// when
-		PagedResponseDto<MyBidResponseDto> result = auctionFacade.getMyBids(memberId, null, pageable);
+        // Facade가 ID로 Auction을 조회함
+        given(auctionRepository.findAllById(anySet())).willReturn(List.of(auction));
 
-		// then
-		assertThat(result.data()).hasSize(1);
-		MyBidResponseDto dto = result.data().get(0);
+        // when
+        PagedResponseDto<MyBidResponseDto> result = auctionFacade.getMyBids(memberId, null, pageable);
 
-		assertThat(dto.auctionStatus()).isEqualTo(AuctionStatus.IN_PROGRESS);
-		assertThat(dto.bidAmount()).isEqualTo(15000);
+        // then
+        assertThat(result.data()).hasSize(1);
+        MyBidResponseDto dto = result.data().get(0);
 
-		// (선택) 현재가 확인
-		assertThat(dto.currentPrice()).isEqualTo(15000);
-	}
+        assertThat(dto.auctionStatus()).isEqualTo(AuctionStatus.IN_PROGRESS);
+        assertThat(dto.bidAmount()).isEqualTo(15000);
+
+        // (선택) 현재가 확인
+        assertThat(dto.currentPrice()).isEqualTo(15000);
+    }
+
+    @Nested
+    @DisplayName("결제 타임아웃 처리")
+    class ProcessPaymentTimeoutTests {
+
+        @Test
+        @DisplayName("UseCase 호출 후 결과 반환")
+        void processPaymentTimeout_callsUseCaseAndReturnsResult() {
+            // given
+            List<AuctionPaymentTimeoutResponse.TimeoutDetail> details = List.of(
+                    new AuctionPaymentTimeoutResponse.TimeoutDetail(1L, 100L, 200L, 3000, AuctionOrderStatus.FAILED),
+                    new AuctionPaymentTimeoutResponse.TimeoutDetail(2L, 101L, 201L, 5000, AuctionOrderStatus.FAILED)
+            );
+
+            AuctionPaymentTimeoutResponse expectedResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    2,
+                    details
+            );
+
+            given(auctionProcessTimeoutUseCase.execute()).willReturn(expectedResponse);
+
+            // when
+            AuctionPaymentTimeoutResponse result = auctionFacade.processPaymentTimeout();
+
+            // then
+            assertThat(result).isEqualTo(expectedResponse);
+            assertThat(result.processedCount()).isEqualTo(2);
+            assertThat(result.details()).hasSize(2);
+
+            verify(auctionProcessTimeoutUseCase, times(1)).execute();
+        }
+
+        @Test
+        @DisplayName("타임아웃 대상 없으면 빈 결과 반환")
+        void processPaymentTimeout_noTargets_returnsEmptyResult() {
+            // given
+            AuctionPaymentTimeoutResponse expectedResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    0,
+                    List.of()
+            );
+
+            given(auctionProcessTimeoutUseCase.execute()).willReturn(expectedResponse);
+
+            // when
+            AuctionPaymentTimeoutResponse result = auctionFacade.processPaymentTimeout();
+
+            // then
+            assertThat(result.processedCount()).isZero();
+            assertThat(result.details()).isEmpty();
+
+            verify(auctionProcessTimeoutUseCase, times(1)).execute();
+        }
+
+        @Test
+        @DisplayName("requestTime이 포함된 응답 반환")
+        void processPaymentTimeout_responseContainsRequestTime() {
+            // given
+            LocalDateTime requestTime = LocalDateTime.of(2026, 1, 18, 15, 30, 0);
+            AuctionPaymentTimeoutResponse expectedResponse = new AuctionPaymentTimeoutResponse(
+                    requestTime,
+                    0,
+                    List.of()
+            );
+
+            given(auctionProcessTimeoutUseCase.execute()).willReturn(expectedResponse);
+
+            // when
+            AuctionPaymentTimeoutResponse result = auctionFacade.processPaymentTimeout();
+
+            // then
+            assertThat(result.requestTime()).isEqualTo(requestTime);
+        }
+    }
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacadeTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacadeTest.java
@@ -1,13 +1,20 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
+import com.bugzero.rarego.boundedContext.auction.domain.*;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionMemberRepository;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
+import com.bugzero.rarego.boundedContext.auction.out.BidRepository;
+import com.bugzero.rarego.boundedContext.product.out.ProductRepository;
+import com.bugzero.rarego.global.response.PagedResponseDto;
+import com.bugzero.rarego.global.response.SuccessResponseDto;
+import com.bugzero.rarego.global.response.SuccessType;
+import com.bugzero.rarego.shared.auction.dto.BidLogResponseDto;
+import com.bugzero.rarego.shared.auction.dto.BidResponseDto;
+import com.bugzero.rarego.shared.auction.dto.MyBidResponseDto;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,237 +25,259 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionMember;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrderStatus;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
-import com.bugzero.rarego.boundedContext.auction.domain.Bid;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionMemberRepository;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
-import com.bugzero.rarego.boundedContext.auction.out.BidRepository;
-import com.bugzero.rarego.boundedContext.product.domain.Product;
-import com.bugzero.rarego.boundedContext.product.out.ProductRepository;
-import com.bugzero.rarego.global.response.PagedResponseDto;
-import com.bugzero.rarego.global.response.SuccessResponseDto;
-import com.bugzero.rarego.global.response.SuccessType;
-import com.bugzero.rarego.shared.auction.dto.AuctionFilterType;
-import com.bugzero.rarego.shared.auction.dto.BidLogResponseDto;
-import com.bugzero.rarego.shared.auction.dto.BidResponseDto;
-import com.bugzero.rarego.shared.auction.dto.MyBidResponseDto;
-import com.bugzero.rarego.shared.auction.dto.MySaleResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionFacadeTest {
 
-	@InjectMocks
-	private AuctionFacade auctionFacade;
+    @InjectMocks
+    private AuctionFacade auctionFacade;
 
-	@Mock
-	private AuctionCreateBidUseCase auctionCreateBidUseCase;
+    // UseCases
+    @Mock
+    private AuctionCreateBidUseCase auctionCreateBidUseCase;
+    @Mock
+    private AuctionProcessTimeoutUseCase auctionProcessTimeoutUseCase;
 
-	@Mock
-	private BidRepository bidRepository;
-	@Mock
-	private AuctionMemberRepository auctionMemberRepository;
-	@Mock
-	private AuctionRepository auctionRepository;
-	@Mock
-	private ProductRepository productRepository;
-	@Mock
-	private AuctionOrderRepository auctionOrderRepository;
+    // Repositories
+    @Mock
+    private BidRepository bidRepository;
+    @Mock
+    private AuctionMemberRepository auctionMemberRepository;
+    @Mock
+    private AuctionRepository auctionRepository;
+    @Mock
+    private ProductRepository productRepository;
+    @Mock
+    private AuctionOrderRepository auctionOrderRepository;
 
-	@Test
-	@DisplayName("입찰 생성 요청 시 UseCase를 호출하고 결과를 반환한다")
-	void createBid_Success() {
-		// given
-		Long auctionId = 1L;
-		Long memberId = 100L;
-		int bidAmount = 50000;
+    @Test
+    @DisplayName("입찰 생성 요청 시 UseCase를 호출하고 결과를 반환한다")
+    void createBid_Success() {
+        // given
+        Long auctionId = 1L;
+        Long memberId = 100L;
+        int bidAmount = 50000;
 
-		// [수정] Builder 대신 생성자 사용 (Record)
-		BidResponseDto bidResponse = new BidResponseDto(
-			1L, auctionId, "public-id", LocalDateTime.now(), (long) bidAmount, (long) bidAmount
-		);
+        BidResponseDto bidResponse = new BidResponseDto(
+                1L, auctionId, "public-id", LocalDateTime.now(), (long) bidAmount, (long) bidAmount
+        );
 
-		SuccessResponseDto<BidResponseDto> expectedResponse = SuccessResponseDto.from(
-			SuccessType.CREATED,
-			bidResponse
-		);
+        SuccessResponseDto<BidResponseDto> expectedResponse = SuccessResponseDto.from(
+                SuccessType.CREATED,
+                bidResponse
+        );
 
-		given(auctionCreateBidUseCase.createBid(auctionId, memberId, bidAmount))
-			.willReturn(expectedResponse);
+        given(auctionCreateBidUseCase.createBid(auctionId, memberId, bidAmount))
+                .willReturn(expectedResponse);
 
-		// when
-		SuccessResponseDto<BidResponseDto> result = auctionFacade.createBid(auctionId, memberId, bidAmount);
+        // when
+        SuccessResponseDto<BidResponseDto> result = auctionFacade.createBid(auctionId, memberId, bidAmount);
 
-		// then
-		assertThat(result).isEqualTo(expectedResponse);
-		verify(auctionCreateBidUseCase).createBid(auctionId, memberId, bidAmount);
-	}
+        // then
+        assertThat(result).isEqualTo(expectedResponse);
+        verify(auctionCreateBidUseCase).createBid(auctionId, memberId, bidAmount);
+    }
 
-	@Test
-	@DisplayName("경매 입찰 기록 조회: 입찰자와 매핑하여 반환한다")
-	void getBidLogs_Success() {
-		// given
-		Long auctionId = 1L;
-		Long bidderId = 100L;
-		Pageable pageable = PageRequest.of(0, 10);
+    @Test
+    @DisplayName("경매 입찰 기록 조회: 입찰자와 매핑하여 반환한다")
+    void getBidLogs_Success() {
+        // given
+        Long auctionId = 1L;
+        Long bidderId = 100L;
+        Pageable pageable = PageRequest.of(0, 10);
 
-		Bid bid = Bid.builder()
-			.auctionId(auctionId)
-			.bidderId(bidderId)
-			.bidAmount(50000)
-			.build();
-		ReflectionTestUtils.setField(bid, "id", 1L);
-		// BaseIdAndTime 필드 세팅 (필요 시)
-		// ReflectionTestUtils.setField(bid, "createdAt", LocalDateTime.now());
+        Bid bid = Bid.builder()
+                .auctionId(auctionId)
+                .bidderId(bidderId)
+                .bidAmount(50000)
+                .build();
+        ReflectionTestUtils.setField(bid, "id", 1L);
 
-		AuctionMember bidder = AuctionMember.builder().publicId("user_masked").build();
-		ReflectionTestUtils.setField(bidder, "id", bidderId);
+        AuctionMember bidder = AuctionMember.builder().publicId("user_masked").build();
+        ReflectionTestUtils.setField(bidder, "id", bidderId);
 
-		given(bidRepository.findAllByAuctionIdOrderByBidTimeDesc(eq(auctionId), any(Pageable.class)))
-			.willReturn(new PageImpl<>(List.of(bid)));
+        given(bidRepository.findAllByAuctionIdOrderByBidTimeDesc(eq(auctionId), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(bid)));
 
-		given(auctionMemberRepository.findAllById(anySet())).willReturn(List.of(bidder));
+        given(auctionMemberRepository.findAllById(anySet())).willReturn(List.of(bidder));
 
-		// when
-		PagedResponseDto<BidLogResponseDto> result = auctionFacade.getBidLogs(auctionId, pageable);
+        // when
+        PagedResponseDto<BidLogResponseDto> result = auctionFacade.getBidLogs(auctionId, pageable);
 
-		// then
-		assertThat(result.data()).hasSize(1);
-		assertThat(result.data().get(0).publicId()).isEqualTo("user_masked");
-		assertThat(result.data().get(0).bidAmount()).isEqualTo(50000);
-	}
+        // then
+        assertThat(result.data()).hasSize(1);
+        assertThat(result.data().get(0).publicId()).isEqualTo("user_masked");
+        assertThat(result.data().get(0).bidAmount()).isEqualTo(50000);
+    }
 
-	@Test
-	@DisplayName("나의 입찰 내역 조회: 경매 정보와 매핑하여 반환한다")
-	void getMyBids_Success() {
-		// given
-		Long memberId = 100L;
-		Long auctionId = 10L;
-		Pageable pageable = PageRequest.of(0, 10);
+    @Test
+    @DisplayName("나의 입찰 내역 조회: 경매 정보와 매핑하여 반환한다")
+    void getMyBids_Success() {
+        // given
+        Long memberId = 100L;
+        Long auctionId = 10L;
+        Pageable pageable = PageRequest.of(0, 10);
 
-		Auction auction = Auction.builder()
-			.productId(50L)
-			.startPrice(10000)
-			.tickSize(1000)
-			.startTime(LocalDateTime.now())
-			.endTime(LocalDateTime.now().plusDays(1))
-			.durationDays(1)
-			.build();
-		ReflectionTestUtils.setField(auction, "id", auctionId);
-		auction.startAuction();
-		auction.updateCurrentPrice(15000);
+        Auction auction = Auction.builder()
+                .productId(50L)
+                .startPrice(10000)
+                .tickSize(1000)
+                .startTime(LocalDateTime.now())
+                .endTime(LocalDateTime.now().plusDays(1))
+                .durationDays(1)
+                .build();
+        ReflectionTestUtils.setField(auction, "id", auctionId);
+        auction.startAuction();
+        auction.updateCurrentPrice(15000);
 
-		Bid bid = Bid.builder()
-			.auctionId(auctionId)
-			.bidderId(memberId)
-			.bidAmount(15000)
-			.build();
-		ReflectionTestUtils.setField(bid, "id", 1L);
+        Bid bid = Bid.builder()
+                .auctionId(auctionId)
+                .bidderId(memberId)
+                .bidAmount(15000)
+                .build();
+        ReflectionTestUtils.setField(bid, "id", 1L);
 
-		given(bidRepository.findMyBids(eq(memberId), eq(null), any(Pageable.class)))
-			.willReturn(new PageImpl<>(List.of(bid)));
+        given(bidRepository.findMyBids(eq(memberId), isNull(), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(bid)));
 
-		given(auctionRepository.findAllById(anySet())).willReturn(List.of(auction));
+        given(auctionRepository.findAllById(anySet())).willReturn(List.of(auction));
 
-		// when
-		PagedResponseDto<MyBidResponseDto> result = auctionFacade.getMyBids(memberId, null, pageable);
+        // when
+        PagedResponseDto<MyBidResponseDto> result = auctionFacade.getMyBids(memberId, null, pageable);
 
-		// then
-		assertThat(result.data()).hasSize(1);
-		MyBidResponseDto dto = result.data().get(0);
-		assertThat(dto.auctionStatus()).isEqualTo(AuctionStatus.IN_PROGRESS);
-		assertThat(dto.bidAmount()).isEqualTo(15000);
-		assertThat(dto.currentPrice()).isEqualTo(15000);
-	}
+        // then
+        assertThat(result.data()).hasSize(1);
+        MyBidResponseDto dto = result.data().get(0);
+        assertThat(dto.auctionStatus()).isEqualTo(AuctionStatus.IN_PROGRESS);
+        assertThat(dto.bidAmount()).isEqualTo(15000);
+        assertThat(dto.currentPrice()).isEqualTo(15000);
+    }
 
-	/*
-	@Test
-	@DisplayName("나의 판매 목록 조회: 상품, 주문, 입찰수 정보를 종합하여 반환한다")
-	void getMySales_Success() {
-	    // given
-	    Long sellerId = 1L;
-	    AuctionFilterType filter = AuctionFilterType.ALL;
-	    Pageable pageable = PageRequest.of(0, 10);
-	
-	    given(productRepository.findAllIdsBySellerId(sellerId)).willReturn(List.of(10L, 20L));
-	
-	    // --- Auction 1 세팅 ---
-	    Auction auction1 = Auction.builder()
-	        .productId(10L)
-	        .sellerId(sellerId)
-	        .startPrice(1000)
-	        .tickSize(100)
-	        .startTime(LocalDateTime.now().minusHours(1))
-	        .endTime(LocalDateTime.now().plusDays(1))
-	        .build();
-	    // [중요] currentPrice 초기화 (int 변환 시 NPE 방지)
-	    auction1.updateCurrentPrice(0); 
-	    // [중요] ID 주입
-	    ReflectionTestUtils.setField(auction1, "id", 100L);
-	    auction1.startAuction();
-	
-	    // --- Auction 2 세팅 ---
-	    Auction auction2 = Auction.builder()
-	        .productId(20L)
-	        .sellerId(sellerId)
-	        .startPrice(2000)
-	        .tickSize(100)
-	        .startTime(LocalDateTime.now().plusDays(1))
-	        .endTime(LocalDateTime.now().plusDays(2))
-	        .build();
-	    auction2.updateCurrentPrice(0);
-	    ReflectionTestUtils.setField(auction2, "id", 200L);
-	
-	    given(auctionRepository.findAllByProductIdIn(anyList(), any(Pageable.class)))
-	        .willReturn(new PageImpl<>(List.of(auction1, auction2)));
-	
-	    // --- Product 세팅 ---
-	    Product product1 = Product.builder().name("Product 1").sellerId(sellerId).build();
-	    ReflectionTestUtils.setField(product1, "id", 10L);
-	    Product product2 = Product.builder().name("Product 2").sellerId(sellerId).build();
-	    ReflectionTestUtils.setField(product2, "id", 20L);
-	
-	    given(productRepository.findAllByIdIn(anySet())).willReturn(List.of(product1, product2));
-	
-	    // --- AuctionOrder 세팅 (여기가 핵심!) ---
-	    AuctionOrder order = AuctionOrder.builder()
-	        .auctionId(100L)
-	        .sellerId(sellerId)
-	        .bidderId(2L)
-	        .finalPrice(50000)
-	        .build();
-	    
-	    // [★핵심 수정] Builder에 status가 없으므로 null 상태임 -> Reflection으로 값 주입 필수!
-	    ReflectionTestUtils.setField(order, "status", AuctionOrderStatus.PROCESSING);
-	
-	    given(auctionOrderRepository.findAllByAuctionIdIn(anySet())).willReturn(List.of(order));
-	
-	    // --- Bid Count 세팅 ---
-	    // Object[]의 타입이 (Long, Long)인지 확인
-	    given(bidRepository.countByAuctionIdIn(anySet()))
-	        .willReturn(List.of(new Object[]{100L, 5L}, new Object[]{200L, 0L}));
-	
-	    // when
-	    PagedResponseDto<MySaleResponseDto> result = auctionFacade.getMySales(sellerId, filter, pageable);
-	
-	    // then
-	    assertThat(result.data()).hasSize(2);
-	
-	    MySaleResponseDto dto1 = result.data().stream()
-	        .filter(d -> d.auctionId().equals(100L)).findFirst().orElseThrow();
-	    assertThat(dto1.title()).isEqualTo("Product 1");
-	    assertThat(dto1.bidCount()).isEqualTo(5);
-	    assertThat(dto1.tradeStatus()).isEqualTo(AuctionOrderStatus.PROCESSING);
-	
-	    MySaleResponseDto dto2 = result.data().stream()
-	        .filter(d -> d.auctionId().equals(200L)).findFirst().orElseThrow();
-	    assertThat(dto2.title()).isEqualTo("Product 2");
-	    assertThat(dto2.bidCount()).isEqualTo(0);
-	    assertThat(dto2.tradeStatus()).isNull();
-	}
-	*/
+    @Nested
+    @DisplayName("결제 타임아웃 처리")
+    class ProcessPaymentTimeoutTests {
+
+        @Test
+        @DisplayName("UseCase 호출 후 결과 반환")
+        void processPaymentTimeout_callsUseCaseAndReturnsResult() {
+            // given
+            List<AuctionPaymentTimeoutResponse.TimeoutDetail> details = List.of(
+                    new AuctionPaymentTimeoutResponse.TimeoutDetail(1L, 100L, 200L, 3000, AuctionOrderStatus.FAILED),
+                    new AuctionPaymentTimeoutResponse.TimeoutDetail(2L, 101L, 201L, 5000, AuctionOrderStatus.FAILED)
+            );
+
+            AuctionPaymentTimeoutResponse expectedResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    2,
+                    details
+            );
+
+            given(auctionProcessTimeoutUseCase.execute()).willReturn(expectedResponse);
+
+            // when
+            AuctionPaymentTimeoutResponse result = auctionFacade.processPaymentTimeout();
+
+            // then
+            assertThat(result).isEqualTo(expectedResponse);
+            assertThat(result.processedCount()).isEqualTo(2);
+            verify(auctionProcessTimeoutUseCase, times(1)).execute();
+        }
+
+        @Test
+        @DisplayName("타임아웃 대상 없으면 빈 결과 반환")
+        void processPaymentTimeout_noTargets_returnsEmptyResult() {
+            // given
+            AuctionPaymentTimeoutResponse expectedResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    0,
+                    List.of()
+            );
+
+            given(auctionProcessTimeoutUseCase.execute()).willReturn(expectedResponse);
+
+            // when
+            AuctionPaymentTimeoutResponse result = auctionFacade.processPaymentTimeout();
+
+            // then
+            assertThat(result.processedCount()).isZero();
+            verify(auctionProcessTimeoutUseCase, times(1)).execute();
+        }
+    }
+
+    /*
+     * TODO: GitHub Actions 환경에서 실패하는 문제 해결 필요
+     * @Test
+    @DisplayName("나의 판매 목록 조회: 상품, 주문, 입찰수 정보를 종합하여 반환한다")
+    void getMySales_Success() {
+        Long sellerId = 1L;
+        AuctionFilterType filter = AuctionFilterType.ALL;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        given(productRepository.findAllIdsBySellerId(sellerId)).willReturn(List.of(10L, 20L));
+
+        Auction auction1 = Auction.builder()
+            .productId(10L)
+            .sellerId(sellerId)
+            .startPrice(1000)
+            .tickSize(100)
+            .startTime(LocalDateTime.now().minusHours(1))
+            .endTime(LocalDateTime.now().plusDays(1))
+            .build();
+        auction1.updateCurrentPrice(0);
+        ReflectionTestUtils.setField(auction1, "id", 100L);
+        auction1.startAuction();
+
+        Auction auction2 = Auction.builder()
+            .productId(20L)
+            .sellerId(sellerId)
+            .startPrice(2000)
+            .tickSize(100)
+            .startTime(LocalDateTime.now().plusDays(1))
+            .endTime(LocalDateTime.now().plusDays(2))
+            .build();
+        auction2.updateCurrentPrice(0);
+        ReflectionTestUtils.setField(auction2, "id", 200L);
+
+        given(auctionRepository.findAllByProductIdIn(anyList(), any(Pageable.class)))
+            .willReturn(new PageImpl<>(List.of(auction1, auction2)));
+
+        Product product1 = Product.builder().name("Product 1").sellerId(sellerId).build();
+        ReflectionTestUtils.setField(product1, "id", 10L);
+        Product product2 = Product.builder().name("Product 2").sellerId(sellerId).build();
+        ReflectionTestUtils.setField(product2, "id", 20L);
+
+        given(productRepository.findAllByIdIn(anySet())).willReturn(List.of(product1, product2));
+
+        AuctionOrder order = AuctionOrder.builder()
+            .auctionId(100L)
+            .sellerId(sellerId)
+            .bidderId(2L)
+            .finalPrice(50000)
+            .build();
+        ReflectionTestUtils.setField(order, "status", AuctionOrderStatus.PROCESSING);
+
+        given(auctionOrderRepository.findAllByAuctionIdIn(anySet())).willReturn(List.of(order));
+
+        given(bidRepository.countByAuctionIdIn(anySet()))
+            .willReturn(List.of(new Object[]{100L, 5L}, new Object[]{200L, 0L}));
+
+        PagedResponseDto<MySaleResponseDto> result = auctionFacade.getMySales(sellerId, filter, pageable);
+
+        assertThat(result.data()).hasSize(2);
+
+        MySaleResponseDto dto1 = result.data().stream()
+            .filter(d -> d.auctionId().equals(100L)).findFirst().orElseThrow();
+        assertThat(dto1.title()).isEqualTo("Product 1");
+        assertThat(dto1.bidCount()).isEqualTo(5);
+        assertThat(dto1.tradeStatus()).isEqualTo(AuctionOrderStatus.PROCESSING);
+    }
+    */
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionProcessTimeoutUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionProcessTimeoutUseCaseTest.java
@@ -1,0 +1,196 @@
+package com.bugzero.rarego.boundedContext.auction.app;
+
+import com.bugzero.rarego.boundedContext.auction.domain.Auction;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrderStatus;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
+import com.bugzero.rarego.boundedContext.auction.domain.event.AuctionPaymentTimeoutEvent;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuctionProcessTimeoutUseCaseTest {
+
+    @InjectMocks
+    private AuctionProcessTimeoutUseCase useCase;
+
+    @Mock
+    private AuctionOrderRepository orderRepository;
+
+    @Mock
+    private AuctionRepository auctionRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private AuctionOrder testOrder;
+    private Auction testAuction;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 AuctionOrder 생성
+        testOrder = AuctionOrder.builder()
+                .auctionId(1L)
+                .sellerId(100L)
+                .bidderId(200L)
+                .finalPrice(50000)
+                .build();
+        ReflectionTestUtils.setField(testOrder, "id", 1L);
+        ReflectionTestUtils.setField(testOrder, "status", AuctionOrderStatus.PROCESSING);
+        ReflectionTestUtils.setField(testOrder, "createdAt", LocalDateTime.now().minusHours(25));
+
+        // 테스트용 Auction 생성
+        testAuction = Auction.builder()
+                .productId(10L)
+                .sellerId(100L)
+                .startTime(LocalDateTime.now().minusDays(2))
+                .endTime(LocalDateTime.now().minusDays(1))
+                .startPrice(10000)
+                .tickSize(1000)
+                .build();
+        ReflectionTestUtils.setField(testAuction, "id", 1L);
+        ReflectionTestUtils.setField(testAuction, "status", AuctionStatus.ENDED);
+    }
+
+    @Test
+    @DisplayName("타임아웃 대상 주문이 없으면 빈 결과 반환")
+    void execute_noTimeoutOrders_returnsEmptyResult() {
+        // given
+        given(orderRepository.findByStatusAndCreatedAtBefore(
+                eq(AuctionOrderStatus.PROCESSING), any(LocalDateTime.class)))
+                .willReturn(Collections.emptyList());
+
+        // when
+        AuctionPaymentTimeoutResponse response = useCase.execute();
+
+        // then
+        assertThat(response.processedCount()).isZero();
+        assertThat(response.details()).isEmpty();
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("타임아웃 대상 주문 처리 성공")
+    void execute_withTimeoutOrders_processesSuccessfully() {
+        // given
+        given(orderRepository.findByStatusAndCreatedAtBefore(
+                eq(AuctionOrderStatus.PROCESSING), any(LocalDateTime.class)))
+                .willReturn(List.of(testOrder));
+        given(auctionRepository.findById(1L))
+                .willReturn(Optional.of(testAuction));
+
+        // when
+        AuctionPaymentTimeoutResponse response = useCase.execute();
+
+        // then
+        assertThat(response.processedCount()).isEqualTo(1);
+        assertThat(response.details()).hasSize(1);
+
+        AuctionPaymentTimeoutResponse.TimeoutDetail detail = response.details().get(0);
+        assertThat(detail.orderId()).isEqualTo(1L);
+        assertThat(detail.auctionId()).isEqualTo(1L);
+        assertThat(detail.buyerId()).isEqualTo(200L);
+        assertThat(detail.status()).isEqualTo(AuctionOrderStatus.FAILED);
+
+        // 주문 상태 변경 확인
+        assertThat(testOrder.getStatus()).isEqualTo(AuctionOrderStatus.FAILED);
+
+        // 경매 상태는 ENDED 유지 (변경 없음)
+        assertThat(testAuction.getStatus()).isEqualTo(AuctionStatus.ENDED);
+
+        // 이벤트 발행 확인
+        verify(eventPublisher).publishEvent(any(AuctionPaymentTimeoutEvent.class));
+    }
+
+    @Test
+    @DisplayName("여러 주문 중 일부 실패해도 나머지는 처리됨")
+    void execute_partialFailure_continuesProcessing() {
+        // given
+        AuctionOrder order1 = AuctionOrder.builder()
+                .auctionId(1L)
+                .sellerId(100L)
+                .bidderId(200L)
+                .finalPrice(50000)
+                .build();
+        ReflectionTestUtils.setField(order1, "id", 1L);
+        ReflectionTestUtils.setField(order1, "status", AuctionOrderStatus.PROCESSING);
+
+        AuctionOrder order2 = AuctionOrder.builder()
+                .auctionId(2L)
+                .sellerId(101L)
+                .bidderId(201L)
+                .finalPrice(60000)
+                .build();
+        ReflectionTestUtils.setField(order2, "id", 2L);
+        ReflectionTestUtils.setField(order2, "status", AuctionOrderStatus.PROCESSING);
+
+        Auction auction2 = Auction.builder()
+                .productId(11L)
+                .sellerId(101L)
+                .startTime(LocalDateTime.now().minusDays(2))
+                .endTime(LocalDateTime.now().minusDays(1))
+                .startPrice(20000)
+                .tickSize(1000)
+                .build();
+        ReflectionTestUtils.setField(auction2, "id", 2L);
+        ReflectionTestUtils.setField(auction2, "status", AuctionStatus.ENDED);
+
+        given(orderRepository.findByStatusAndCreatedAtBefore(
+                eq(AuctionOrderStatus.PROCESSING), any(LocalDateTime.class)))
+                .willReturn(List.of(order1, order2));
+        given(auctionRepository.findById(1L))
+                .willReturn(Optional.empty()); // 첫 번째는 실패
+        given(auctionRepository.findById(2L))
+                .willReturn(Optional.of(auction2)); // 두 번째는 성공
+
+        // when
+        AuctionPaymentTimeoutResponse response = useCase.execute();
+
+        // then
+        assertThat(response.processedCount()).isEqualTo(1);
+        assertThat(response.details()).hasSize(1);
+        assertThat(response.details().get(0).orderId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("응답에 requestTime이 포함됨")
+    void execute_responseContainsRequestTime() {
+        // given
+        given(orderRepository.findByStatusAndCreatedAtBefore(
+                eq(AuctionOrderStatus.PROCESSING), any(LocalDateTime.class)))
+                .willReturn(Collections.emptyList());
+
+        LocalDateTime before = LocalDateTime.now();
+
+        // when
+        AuctionPaymentTimeoutResponse response = useCase.execute();
+
+        LocalDateTime after = LocalDateTime.now();
+
+        // then
+        assertThat(response.requestTime()).isAfterOrEqualTo(before);
+        assertThat(response.requestTime()).isBeforeOrEqualTo(after);
+    }
+}

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/in/InternalAuctionControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/in/InternalAuctionControllerTest.java
@@ -1,10 +1,15 @@
 package com.bugzero.rarego.boundedContext.auction.in;
 
+import com.bugzero.rarego.boundedContext.auction.app.AuctionFacade;
 import com.bugzero.rarego.boundedContext.auction.app.AuctionSettleAuctionFacade;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrderStatus;
 import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionAutoSettleResponseDto;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse.TimeoutDetail;
 import com.bugzero.rarego.global.aspect.ResponseAspect;
 import com.bugzero.rarego.global.response.SuccessType;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -27,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = InternalAuctionController.class)
 @Import(ResponseAspect.class)
 @AutoConfigureMockMvc(addFilters = false)
-class InternalAuctionControllerTest { // 테스트 클래스명은 컨트롤러와 맞춤
+class InternalAuctionControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -35,53 +40,124 @@ class InternalAuctionControllerTest { // 테스트 클래스명은 컨트롤러�
     @MockitoBean
     private AuctionSettleAuctionFacade facade;
 
-    @Test
-    @DisplayName("경매 자동 낙찰 처리 API 호출 성공")
-    void settle_Success() throws Exception {
-        // given - dev에서 변경된 AuctionAutoResponseDto 사용
-        AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
-                .requestTime(LocalDateTime.now())
-                .processedCount(10)
-                .successCount(8)
-                .failCount(2)
-                .details(List.of())
-                .build();
+    @MockitoBean
+    private AuctionFacade auctionFacade; // 타임아웃 처리를 위한 Facade 유지
 
-        given(facade.settle()).willReturn(mockResponse);
+    @Nested
+    @DisplayName("경매 정산 API")
+    class SettleTests {
 
-        // when & then
-        mockMvc.perform(post("/api/v1/internal/auctions/settle"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
-                .andExpect(jsonPath("$.message").value(SuccessType.OK.getMessage()))
-                .andExpect(jsonPath("$.data.processedCount").value(10))
-                .andExpect(jsonPath("$.data.successCount").value(8))
-                .andExpect(jsonPath("$.data.failCount").value(2));
+        @Test
+        @DisplayName("경매 자동 낙찰 처리 API 호출 성공")
+        void settle_Success() throws Exception {
+            // given
+            AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
+                    .requestTime(LocalDateTime.now())
+                    .processedCount(10)
+                    .successCount(8)
+                    .failCount(2)
+                    .details(List.of())
+                    .build();
 
-        verify(facade, times(1)).settle();
+            given(facade.settle()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/settle"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
+                    .andExpect(jsonPath("$.message").value(SuccessType.OK.getMessage()))
+                    .andExpect(jsonPath("$.data.processedCount").value(10))
+                    .andExpect(jsonPath("$.data.successCount").value(8))
+                    .andExpect(jsonPath("$.data.failCount").value(2));
+
+            verify(facade, times(1)).settle();
+        }
+
+        @Test
+        @DisplayName("처리할 경매가 없는 경우")
+        void settle_NoAuctions() throws Exception {
+            // given
+            AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
+                    .requestTime(LocalDateTime.now())
+                    .processedCount(0)
+                    .successCount(0)
+                    .failCount(0)
+                    .details(List.of())
+                    .build();
+
+            given(facade.settle()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/settle"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.processedCount").value(0));
+
+            verify(facade, times(1)).settle();
+        }
     }
 
-    @Test
-    @DisplayName("처리할 경매가 없는 경우")
-    void settle_NoAuctions() throws Exception {
-        // given
-        AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
-                .requestTime(LocalDateTime.now())
-                .processedCount(0)
-                .successCount(0)
-                .failCount(0)
-                .details(List.of())
-                .build();
+    @Nested
+    @DisplayName("결제 타임아웃 API")
+    class TimeoutTests {
 
-        given(facade.settle()).willReturn(mockResponse);
+        @Test
+        @DisplayName("타임아웃 처리 성공")
+        void processPaymentTimeout_Success() throws Exception {
+            // given
+            List<TimeoutDetail> details = List.of(
+                    new TimeoutDetail(7001L, 1001L, 55L, 3000, AuctionOrderStatus.FAILED),
+                    new TimeoutDetail(7002L, 1002L, 56L, 5000, AuctionOrderStatus.FAILED)
+            );
 
-        // when & then
-        mockMvc.perform(post("/api/v1/internal/auctions/settle"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.processedCount").value(0));
+            AuctionPaymentTimeoutResponse mockResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    2,
+                    details
+            );
 
-        verify(facade, times(1)).settle();
+            given(auctionFacade.processPaymentTimeout()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/timeout"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
+                    .andExpect(jsonPath("$.message").value(SuccessType.OK.getMessage()))
+                    .andExpect(jsonPath("$.data.processedCount").value(2))
+                    .andExpect(jsonPath("$.data.details").isArray())
+                    .andExpect(jsonPath("$.data.details[0].orderId").value(7001))
+                    .andExpect(jsonPath("$.data.details[0].auctionId").value(1001))
+                    .andExpect(jsonPath("$.data.details[0].buyerId").value(55))
+                    .andExpect(jsonPath("$.data.details[0].penaltyAmount").value(3000))
+                    .andExpect(jsonPath("$.data.details[0].status").value("FAILED"))
+                    .andExpect(jsonPath("$.data.details[1].orderId").value(7002));
+
+            verify(auctionFacade, times(1)).processPaymentTimeout();
+        }
+
+        @Test
+        @DisplayName("타임아웃 대상 주문이 없는 경우")
+        void processPaymentTimeout_NoTargets() throws Exception {
+            // given
+            AuctionPaymentTimeoutResponse mockResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    0,
+                    List.of()
+            );
+
+            given(auctionFacade.processPaymentTimeout()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/timeout"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
+                    .andExpect(jsonPath("$.data.processedCount").value(0))
+                    .andExpect(jsonPath("$.data.details").isEmpty());
+
+            verify(auctionFacade, times(1)).processPaymentTimeout();
+        }
     }
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/in/InternalAuctionControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/in/InternalAuctionControllerTest.java
@@ -1,10 +1,15 @@
 package com.bugzero.rarego.boundedContext.auction.in;
 
+import com.bugzero.rarego.boundedContext.auction.app.AuctionFacade;
 import com.bugzero.rarego.boundedContext.auction.app.AuctionSettleAuctionFacade;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrderStatus;
 import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionAutoSettleResponseDto;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse;
+import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionPaymentTimeoutResponse.TimeoutDetail;
 import com.bugzero.rarego.global.aspect.ResponseAspect;
 import com.bugzero.rarego.global.response.SuccessType;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -35,53 +40,151 @@ class InternalAuctionControllerTest {
     @MockitoBean
     private AuctionSettleAuctionFacade facade;
 
-    @Test
-    @DisplayName("경매 자동 낙찰 처리 API 호출 성공")
-    void settle_Success() throws Exception {
-        // given - DTO 빌더 활용
-        AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
-                .requestTime(LocalDateTime.now())
-                .processedCount(10)
-                .successCount(8)
-                .failCount(2)
-                .details(List.of())
-                .build();
+    @MockitoBean
+    private AuctionFacade auctionFacade;
 
-        given(facade.settle()).willReturn(mockResponse);
+    @Nested
+    @DisplayName("경매 정산 API")
+    class SettleTests {
 
-        // when & then
-        mockMvc.perform(post("/api/v1/internal/auctions/settle"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
-                .andExpect(jsonPath("$.message").value(SuccessType.OK.getMessage()))
-                .andExpect(jsonPath("$.data.processedCount").value(10))
-                .andExpect(jsonPath("$.data.successCount").value(8))
-                .andExpect(jsonPath("$.data.failCount").value(2));
+        @Test
+        @DisplayName("경매 자동 낙찰 처리 API 호출 성공")
+        void settle_Success() throws Exception {
+            // given
+            AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
+                    .requestTime(LocalDateTime.now())
+                    .processedCount(10)
+                    .successCount(8)
+                    .failCount(2)
+                    .details(List.of())
+                    .build();
 
-        verify(facade, times(1)).settle();
+            given(facade.settle()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/settle"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
+                    .andExpect(jsonPath("$.message").value(SuccessType.OK.getMessage()))
+                    .andExpect(jsonPath("$.data.processedCount").value(10))
+                    .andExpect(jsonPath("$.data.successCount").value(8))
+                    .andExpect(jsonPath("$.data.failCount").value(2));
+
+            verify(facade, times(1)).settle();
+        }
+
+        @Test
+        @DisplayName("처리할 경매가 없는 경우")
+        void settle_NoAuctions() throws Exception {
+            // given
+            AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
+                    .requestTime(LocalDateTime.now())
+                    .processedCount(0)
+                    .successCount(0)
+                    .failCount(0)
+                    .details(List.of())
+                    .build();
+
+            given(facade.settle()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/settle"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.processedCount").value(0));
+
+            verify(facade, times(1)).settle();
+        }
     }
 
-    @Test
-    @DisplayName("처리할 경매가 없는 경우")
-    void settle_NoAuctions() throws Exception {
-        // given
-        AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
-                .requestTime(LocalDateTime.now())
-                .processedCount(0)
-                .successCount(0)
-                .failCount(0)
-                .details(List.of())
-                .build();
+    @Nested
+    @DisplayName("결제 타임아웃 API")
+    class TimeoutTests {
 
-        given(facade.settle()).willReturn(mockResponse);
+        @Test
+        @DisplayName("타임아웃 처리 성공")
+        void processPaymentTimeout_Success() throws Exception {
+            // given
+            List<TimeoutDetail> details = List.of(
+                    new TimeoutDetail(7001L, 1001L, 55L, 3000, AuctionOrderStatus.FAILED),
+                    new TimeoutDetail(7002L, 1002L, 56L, 5000, AuctionOrderStatus.FAILED)
+            );
 
-        // when & then
-        mockMvc.perform(post("/api/v1/internal/auctions/settle"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.processedCount").value(0));
+            AuctionPaymentTimeoutResponse mockResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    2,
+                    details
+            );
 
-        verify(facade, times(1)).settle();
+            given(auctionFacade.processPaymentTimeout()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/timeout"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
+                    .andExpect(jsonPath("$.message").value(SuccessType.OK.getMessage()))
+                    .andExpect(jsonPath("$.data.processedCount").value(2))
+                    .andExpect(jsonPath("$.data.details").isArray())
+                    .andExpect(jsonPath("$.data.details[0].orderId").value(7001))
+                    .andExpect(jsonPath("$.data.details[0].auctionId").value(1001))
+                    .andExpect(jsonPath("$.data.details[0].buyerId").value(55))
+                    .andExpect(jsonPath("$.data.details[0].penaltyAmount").value(3000))
+                    .andExpect(jsonPath("$.data.details[0].status").value("FAILED"))
+                    .andExpect(jsonPath("$.data.details[1].orderId").value(7002));
+
+            verify(auctionFacade, times(1)).processPaymentTimeout();
+        }
+
+        @Test
+        @DisplayName("타임아웃 대상 주문이 없는 경우")
+        void processPaymentTimeout_NoTargets() throws Exception {
+            // given
+            AuctionPaymentTimeoutResponse mockResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    0,
+                    List.of()
+            );
+
+            given(auctionFacade.processPaymentTimeout()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/timeout"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
+                    .andExpect(jsonPath("$.data.processedCount").value(0))
+                    .andExpect(jsonPath("$.data.details").isEmpty());
+
+            verify(auctionFacade, times(1)).processPaymentTimeout();
+        }
+
+        @Test
+        @DisplayName("단일 주문 타임아웃 처리")
+        void processPaymentTimeout_SingleOrder() throws Exception {
+            // given
+            List<TimeoutDetail> details = List.of(
+                    new TimeoutDetail(8888L, 9999L, 200L, 0, AuctionOrderStatus.FAILED)
+            );
+
+            AuctionPaymentTimeoutResponse mockResponse = new AuctionPaymentTimeoutResponse(
+                    LocalDateTime.now(),
+                    1,
+                    details
+            );
+
+            given(auctionFacade.processPaymentTimeout()).willReturn(mockResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/internal/auctions/timeout"))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.processedCount").value(1))
+                    .andExpect(jsonPath("$.data.details").isArray())
+                    .andExpect(jsonPath("$.data.details.length()").value(1));
+
+            verify(auctionFacade, times(1)).processPaymentTimeout();
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #83

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->
<img width="936" height="756" alt="image" src="https://github.com/user-attachments/assets/b22b26b8-b0c3-4949-99ca-b20971831ea1" />

- [x] 타임아웃 대상 조회: AuctionOrder.status = PROCESSING AND createdAt < 24시간 전
- [x] 주문 상태 변경: AuctionOrder.status → FAILED
- [x] 이벤트 발행: SSE 브로드캐스트
<img width="752" height="486" alt="image" src="https://github.com/user-attachments/assets/62d87e0c-e14c-48a7-afc0-80f3986dabe9" />
- [ ] Payment 호출 부분은 mock 처리해둠. 추후 연동 예정


## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- 아직 이전 #82 가 머지되지 않아서 커밋이 중복돼서 올라갔는데 맨 마지막 커밋 [feat(auction): 낙찰자 미결제 타임아웃 처리(경매 취소/실패 확정)](https://github.com/prgrms-be-adv-devcourse/beadv4_4_BugZero_BE/pull/85/commits/599ca615734ea5859446157f49cbc70f251f9854) 만 확인해주시면 됩니다!

- 테스트 방법:
```
**1. 테스트 데이터 준비 (DB에 직접 삽입)**
-- 24시간 이상 된 PROCESSING 주문 생성
INSERT INTO AUCTION_AUCTION (id, product_id, seller_id, start_time, end_time, status, start_price, tick_size, created_at)
VALUES (9999, 1, 100, NOW() - INTERVAL 3 DAY, NOW() - INTERVAL 2 DAY, 'ENDED', 10000, 1000, NOW() - INTERVAL 2 DAY);

INSERT INTO AUCTION_AUCTIONORDER (id, auction_id, seller_id, bidder_id, final_price, status, created_at)
VALUES (8888, 9999, 100, 200, 50000, 'PROCESSING', NOW() - INTERVAL 25 HOUR);
```

**2. API 호출**
```
POST http://localhost:8080/api/v1/internal/auctions/timeout
```

**3. 결과 확인**
```
-- 주문 상태 확인
SELECT * FROM AUCTION_AUCTIONORDER WHERE id = 8888;
-- status가 'FAILED'로 변경되어야 함

-- 경매 상태 확인
SELECT * FROM AUCTION_AUCTION WHERE id = 9999;
-- status가 'FAILED'로 변경되어야 함
```


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
15분