### PR TITLE
[FEAT/payment] 정산 내역 조회 api 구현

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
@@ -79,8 +79,9 @@ public class PaymentFacade {
 	 * 지갑 거래 내역 조회
 	 */
 	public PagedResponseDto<WalletTransactionResponseDto> getWalletTransactions(Long memberId, int page, int size,
-		WalletTransactionType transactionType) {
-		return paymentGetWalletTransactionsUseCase.getWalletTransactions(memberId, page, size, transactionType);
+		WalletTransactionType transactionType, LocalDate from, LocalDate to) {
+		return paymentGetWalletTransactionsUseCase.getWalletTransactions(memberId, page, size, transactionType, from,
+			to);
 
 	}
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
@@ -1,7 +1,10 @@
 package com.bugzero.rarego.boundedContext.payment.app;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 
+import com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus;
 import com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType;
 import com.bugzero.rarego.boundedContext.payment.in.dto.AuctionFinalPaymentRequestDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.AuctionFinalPaymentResponseDto;
@@ -9,6 +12,7 @@ import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentConfirmRequestDto
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentConfirmResponseDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
+import com.bugzero.rarego.boundedContext.payment.in.dto.SettlementResponseDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.WalletTransactionResponseDto;
 import com.bugzero.rarego.global.response.PagedResponseDto;
 import com.bugzero.rarego.shared.payment.dto.DepositHoldRequestDto;
@@ -26,6 +30,7 @@ public class PaymentFacade {
 	private final PaymentProcessSettlementUseCase paymentProcessSettlementUseCase;
 	private final PaymentAuctionFinalUseCase paymentAuctionFinalUseCase;
 	private final PaymentGetWalletTransactionsUseCase paymentGetWalletTransactionsUseCase;
+	private final PaymentGetSettlementsUseCase paymentGetSettlementsUseCase;
 
 	/**
 	 * 보증금 홀딩
@@ -77,5 +82,13 @@ public class PaymentFacade {
 		WalletTransactionType transactionType) {
 		return paymentGetWalletTransactionsUseCase.getWalletTransactions(memberId, page, size, transactionType);
 
+	}
+
+	/**
+	 * 정산 내역 조회
+	 */
+	public PagedResponseDto<SettlementResponseDto> getSettlements(Long memberId, int page, int size,
+		SettlementStatus status, LocalDateTime from, LocalDateTime to) {
+		return paymentGetSettlementsUseCase.getSettlements(memberId, page, size, status, from, to);
 	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
@@ -1,6 +1,6 @@
 package com.bugzero.rarego.boundedContext.payment.app;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import org.springframework.stereotype.Service;
 
@@ -88,7 +88,7 @@ public class PaymentFacade {
 	 * 정산 내역 조회
 	 */
 	public PagedResponseDto<SettlementResponseDto> getSettlements(Long memberId, int page, int size,
-		SettlementStatus status, LocalDateTime from, LocalDateTime to) {
+		SettlementStatus status, LocalDate from, LocalDate to) {
 		return paymentGetSettlementsUseCase.getSettlements(memberId, page, size, status, from, to);
 	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetSettlementsUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetSettlementsUseCase.java
@@ -1,0 +1,33 @@
+package com.bugzero.rarego.boundedContext.payment.app;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import com.bugzero.rarego.boundedContext.payment.domain.Settlement;
+import com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus;
+import com.bugzero.rarego.boundedContext.payment.in.dto.SettlementResponseDto;
+import com.bugzero.rarego.boundedContext.payment.out.SettlementRepository;
+import com.bugzero.rarego.global.response.PagedResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentGetSettlementsUseCase {
+	private final SettlementRepository settlementRepository;
+
+	public PagedResponseDto<SettlementResponseDto> getSettlements(Long memberId, int page, int size,
+		SettlementStatus status, LocalDateTime from, LocalDateTime to) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+
+		Page<Settlement> settlements = settlementRepository.findAllBySellerIdAndStatus(memberId, status, from, to,
+			pageable);
+
+		return PagedResponseDto.from(settlements, SettlementResponseDto::from);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetSettlementsUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetSettlementsUseCase.java
@@ -1,5 +1,6 @@
 package com.bugzero.rarego.boundedContext.payment.app;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.springframework.data.domain.Page;
@@ -22,11 +23,14 @@ public class PaymentGetSettlementsUseCase {
 	private final SettlementRepository settlementRepository;
 
 	public PagedResponseDto<SettlementResponseDto> getSettlements(Long memberId, int page, int size,
-		SettlementStatus status, LocalDateTime from, LocalDateTime to) {
+		SettlementStatus status, LocalDate from, LocalDate to) {
 		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
 
-		Page<Settlement> settlements = settlementRepository.findAllBySellerIdAndStatus(memberId, status, from, to,
-			pageable);
+		LocalDateTime fromDateTime = (from != null) ? from.atStartOfDay() : null;
+		LocalDateTime toDateTime = (to != null) ? to.atTime(java.time.LocalTime.MAX) : null;
+
+		Page<Settlement> settlements = settlementRepository.findAllBySellerIdAndStatus(memberId, status, fromDateTime,
+			toDateTime, pageable);
 
 		return PagedResponseDto.from(settlements, SettlementResponseDto::from);
 	}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetWalletTransactionsUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetWalletTransactionsUseCase.java
@@ -1,5 +1,9 @@
 package com.bugzero.rarego.boundedContext.payment.app;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,12 +26,14 @@ public class PaymentGetWalletTransactionsUseCase {
 
 	@Transactional(readOnly = true)
 	public PagedResponseDto<WalletTransactionResponseDto> getWalletTransactions(Long memberId, int page, int size,
-		WalletTransactionType transactionType) {
+		WalletTransactionType transactionType, LocalDate from, LocalDate to) {
 		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
 
+		LocalDateTime fromDateTime = (from != null) ? from.atStartOfDay() : null;
+		LocalDateTime toDateTime = (to != null) ? to.atTime(LocalTime.MAX) : null;
+
 		Page<PaymentTransaction> transactions = paymentTransactionRepository.findAllByMemberIdAndTransactionType(
-			memberId,
-			transactionType, pageable);
+			memberId, transactionType, fromDateTime, toDateTime, pageable);
 
 		return PagedResponseDto.from(transactions, WalletTransactionResponseDto::from);
 	}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
@@ -6,6 +6,7 @@ import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.bugzero.rarego.boundedContext.payment.app.PaymentFacade;
+import com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus;
 import com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType;
 import com.bugzero.rarego.boundedContext.payment.in.dto.AuctionFinalPaymentRequestDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.AuctionFinalPaymentResponseDto;
@@ -22,6 +24,7 @@ import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentConfirmRequestDto
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentConfirmResponseDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
+import com.bugzero.rarego.boundedContext.payment.in.dto.SettlementResponseDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.WalletTransactionResponseDto;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
@@ -92,6 +95,23 @@ public class PaymentController {
 			transactionType);
 
 		return SuccessResponseDto.from(SuccessType.OK, response);
+	}
+
+	@Operation(summary = "정산 내역 조회", description = "정산 내역을 조회합니다.")
+	@GetMapping("me/settlements")
+	public SuccessResponseDto<PagedResponseDto<SettlementResponseDto>> getSettlements(
+		// TODO: 추후 인증 구현시 @AuthenticationPrincipal로 변경 필요 (seller 검증 로직도 이후 추가)
+		@RequestParam Long memberId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size,
+		@RequestParam(required = false) SettlementStatus status,
+		@RequestParam(required = false)
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+		@RequestParam(required = false)
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to
+	) {
+		return SuccessResponseDto.from(SuccessType.OK,
+			paymentFacade.getSettlements(memberId, page, size, status, from, to));
 	}
 
 	// 로컬 정산 배치 테스트용 api

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
@@ -1,5 +1,6 @@
 package com.bugzero.rarego.boundedContext.payment.in;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.springframework.batch.core.job.Job;
@@ -106,9 +107,9 @@ public class PaymentController {
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(required = false) SettlementStatus status,
 		@RequestParam(required = false)
-		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
 		@RequestParam(required = false)
-		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
 	) {
 		return SuccessResponseDto.from(SuccessType.OK,
 			paymentFacade.getSettlements(memberId, page, size, status, from, to));

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentController.java
@@ -89,11 +89,14 @@ public class PaymentController {
 		@RequestParam Long memberId,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "10") int size,
-		@RequestParam(required = false) WalletTransactionType transactionType
+		@RequestParam(required = false) WalletTransactionType transactionType,
+		@RequestParam(required = false)
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+		@RequestParam(required = false)
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
 	) {
 		PagedResponseDto<WalletTransactionResponseDto> response = paymentFacade.getWalletTransactions(memberId, page,
-			size,
-			transactionType);
+			size, transactionType, from, to);
 
 		return SuccessResponseDto.from(SuccessType.OK, response);
 	}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/dto/SettlementResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/dto/SettlementResponseDto.java
@@ -1,0 +1,30 @@
+package com.bugzero.rarego.boundedContext.payment.in.dto;
+
+import java.time.LocalDateTime;
+
+import com.bugzero.rarego.boundedContext.payment.domain.Settlement;
+import com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus;
+
+public record SettlementResponseDto(
+	Long id,
+	Long auctionId,
+	Long sellerId,
+	int salesAmount,
+	int feeAmount,
+	int settlementAmount,
+	SettlementStatus status,
+	LocalDateTime createdAt
+) {
+	public static SettlementResponseDto from(Settlement settlement) {
+		return new SettlementResponseDto(
+			settlement.getId(),
+			settlement.getAuctionId(),
+			settlement.getSeller().getId(),
+			settlement.getSalesAmount(),
+			settlement.getFeeAmount(),
+			settlement.getSettlementAmount(),
+			settlement.getStatus(),
+			settlement.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/out/PaymentTransactionRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/out/PaymentTransactionRepository.java
@@ -1,5 +1,7 @@
 package com.bugzero.rarego.boundedContext.payment.out;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,13 +11,14 @@ import com.bugzero.rarego.boundedContext.payment.domain.PaymentTransaction;
 import com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType;
 
 public interface PaymentTransactionRepository extends JpaRepository<PaymentTransaction, Long> {
-	@Query(
+	@Query("""
+		SELECT pt FROM PaymentTransaction pt
+		WHERE pt.member.id = :memberId
+		AND (:type IS NULL OR pt.transactionType = :type)
+		AND (:from IS NULL OR pt.createdAt >= :from)
+		AND (:to IS NULL OR pt.createdAt <= :to)
 		"""
-			SELECT pt FROM PaymentTransaction pt
-			WHERE pt.member.id = :memberId
-			AND (:type IS NULL OR pt.transactionType = :type)
-			"""
 	)
-	Page<PaymentTransaction> findAllByMemberIdAndTransactionType(Long memberId,
-		WalletTransactionType type, Pageable pageable);
+	Page<PaymentTransaction> findAllByMemberIdAndTransactionType(Long memberId, WalletTransactionType type,
+		LocalDateTime from, LocalDateTime to, Pageable pageable);
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/out/SettlementRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/out/SettlementRepository.java
@@ -1,8 +1,10 @@
 package com.bugzero.rarego.boundedContext.payment.out;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -33,4 +35,14 @@ public interface SettlementRepository extends JpaRepository<Settlement, Long> {
 		    WHERE s.id = :id
 		""")
 	Optional<Settlement> findByIdForUpdate(Long id);
+
+	@Query("""
+		SELECT s FROM Settlement s
+		WHERE s.seller.id = :sellerId
+		AND (:status IS NULL OR s.status = :status)
+		AND (:from IS NULL OR s.createdAt >= :from)
+		AND (:to IS NULL OR s.createdAt <= :to)
+		""")
+	Page<Settlement> findAllBySellerIdAndStatus(Long sellerId, SettlementStatus status, LocalDateTime from,
+		LocalDateTime to, Pageable pageable);
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetSettlementsUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetSettlementsUseCaseTest.java
@@ -1,0 +1,139 @@
+package com.bugzero.rarego.boundedContext.payment.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
+import com.bugzero.rarego.boundedContext.payment.domain.Settlement;
+import com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus;
+import com.bugzero.rarego.boundedContext.payment.in.dto.SettlementResponseDto;
+import com.bugzero.rarego.boundedContext.payment.out.SettlementRepository;
+import com.bugzero.rarego.global.response.PagedResponseDto;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentGetSettlementsUseCaseTest {
+
+	@InjectMocks
+	private PaymentGetSettlementsUseCase useCase;
+
+	@Mock
+	private SettlementRepository settlementRepository;
+
+	@Test
+	@DisplayName("정산 내역 조회 시 LocalDate를 시간 범위(Start~End)로 변환하여 Repository를 호출한다")
+	void getSettlements_success() {
+		// given
+		Long memberId = 1L;
+		Long sellerId = 1L;
+		int page = 0;
+		int size = 10;
+		SettlementStatus status = SettlementStatus.READY;
+
+		// ✅ [변경] 입력값: LocalDate (날짜만)
+		LocalDate fromDate = LocalDate.now().minusDays(7);
+		LocalDate toDate = LocalDate.now();
+
+		// ✅ [변경] 검증값: Service 내부에서 변환될 LocalDateTime 예상값
+		LocalDateTime expectedFrom = fromDate.atStartOfDay();      // 00:00:00
+		LocalDateTime expectedTo = toDate.atTime(LocalTime.MAX);   // 23:59:59.999...
+
+		// 1. 연관 관계 Mocking
+		PaymentMember mockSeller = mock(PaymentMember.class);
+		given(mockSeller.getId()).willReturn(sellerId);
+
+		// 2. Settlement 객체 생성
+		Settlement settlement = Settlement.builder()
+			.auctionId(100L)
+			.seller(mockSeller)
+			.salesAmount(10000)
+			.feeAmount(1000)
+			.settlementAmount(9000)
+			.status(status)
+			.build();
+
+		ReflectionTestUtils.setField(settlement, "id", 50L);
+		ReflectionTestUtils.setField(settlement, "createdAt", LocalDateTime.now());
+
+		Page<Settlement> settlementPage = new PageImpl<>(List.of(settlement));
+
+		// 3. Repository Mocking (변환된 LocalDateTime으로 호출될 것을 정의)
+		given(settlementRepository.findAllBySellerIdAndStatus(
+			eq(memberId),
+			eq(status),
+			eq(expectedFrom), // ★ 변환된 시간 검증
+			eq(expectedTo),   // ★ 변환된 시간 검증
+			any(Pageable.class))
+		).willReturn(settlementPage);
+
+		// when
+		// ✅ [변경] LocalDate 전달
+		PagedResponseDto<SettlementResponseDto> result =
+			useCase.getSettlements(memberId, page, size, status, fromDate, toDate);
+
+		// then
+		assertThat(result.data()).hasSize(1);
+		assertThat(result.data().get(0).id()).isEqualTo(50L);
+
+		// 4. Repository 호출 파라미터 검증
+		verify(settlementRepository).findAllBySellerIdAndStatus(
+			eq(memberId),
+			eq(status),
+			eq(expectedFrom), // ★ 00:00:00 확인
+			eq(expectedTo),   // ★ 23:59:59 확인
+			any(Pageable.class)
+		);
+	}
+
+	@Test
+	@DisplayName("날짜 조건이 null이면 Repository에도 null(시간 범위 없음)이 전달된다")
+	void getSettlements_withNullParams() {
+		// given
+		Long memberId = 1L;
+		Page<Settlement> emptyPage = Page.empty();
+
+		// null -> null 변환 확인
+		given(settlementRepository.findAllBySellerIdAndStatus(
+			eq(memberId),
+			eq(null),
+			eq(null), // fromDateTime
+			eq(null), // toDateTime
+			any(Pageable.class))
+		).willReturn(emptyPage);
+
+		// when
+		// ✅ LocalDate 파라미터 자리에 null 전달
+		PagedResponseDto<SettlementResponseDto> result =
+			useCase.getSettlements(memberId, 0, 10, null, null, null);
+
+		// then
+		assertThat(result.data()).isEmpty();
+
+		verify(settlementRepository).findAllBySellerIdAndStatus(
+			eq(memberId),
+			eq(null),
+			eq(null),
+			eq(null),
+			any(Pageable.class)
+		);
+	}
+}

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetWalletTransactionsUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentGetWalletTransactionsUseCaseTest.java
@@ -1,10 +1,15 @@
 package com.bugzero.rarego.boundedContext.payment.app;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -36,13 +41,21 @@ class PaymentGetWalletTransactionsUseCaseTest {
 	private PaymentTransactionRepository paymentTransactionRepository;
 
 	@Test
-	@DisplayName("지갑 거래 내역을 조회하면 DTO로 변환된 페이지 결과를 반환한다")
+	@DisplayName("지갑 거래 내역을 조회하면 날짜 조건이 시간으로 변환되어 Repository를 호출하고 결과를 반환한다")
 	void getWalletTransactions_success() {
 		// given
 		Long memberId = 1L;
 		int page = 0;
 		int size = 10;
 		WalletTransactionType type = WalletTransactionType.TOPUP_DONE;
+
+		// ✅ [Input] 날짜 조건 (LocalDate)
+		LocalDate fromDate = LocalDate.of(2024, 1, 1);
+		LocalDate toDate = LocalDate.of(2024, 1, 31);
+
+		// ✅ [Expected] Service 내부에서 변환될 시간값 예상
+		LocalDateTime expectedFrom = fromDate.atStartOfDay();      // 2024-01-01 00:00:00
+		LocalDateTime expectedTo = toDate.atTime(LocalTime.MAX);   // 2024-01-31 23:59:59...
 
 		// 1. 실제 객체 생성 (Builder 사용)
 		PaymentTransaction transaction = PaymentTransaction.builder()
@@ -56,53 +69,62 @@ class PaymentGetWalletTransactionsUseCaseTest {
 			.referenceId(123L)
 			.build();
 
-		// 2. ID와 CreatedAt은 Setter가 없으므로 Reflection으로 주입
 		ReflectionTestUtils.setField(transaction, "id", 100L);
-		// BaseIdAndTime 내부 필드명이 "createdAt"이라고 가정
 		ReflectionTestUtils.setField(transaction, "createdAt", LocalDateTime.now());
 
 		Page<PaymentTransaction> entityPage = new PageImpl<>(List.of(transaction));
 
-		// 3. Repository 동작 정의
+		// 2. Repository 동작 정의 (변경된 메서드명과 파라미터 매칭 확인)
 		given(paymentTransactionRepository.findAllByMemberIdAndTransactionType(
 			eq(memberId),
 			eq(type),
+			eq(expectedFrom), // ★ 변환된 LocalDateTime이 넘어오는지 검증
+			eq(expectedTo),   // ★ 변환된 LocalDateTime이 넘어오는지 검증
 			any(Pageable.class))
 		).willReturn(entityPage);
 
 		// when
+		// ✅ LocalDate 파라미터 전달
 		PagedResponseDto<WalletTransactionResponseDto> result =
-			useCase.getWalletTransactions(memberId, page, size, type);
+			useCase.getWalletTransactions(memberId, page, size, type, fromDate, toDate);
 
 		// then
 		// 결과 검증
 		assertThat(result.data()).hasSize(1);
 
 		WalletTransactionResponseDto dto = result.data().get(0);
-		assertThat(dto.id()).isEqualTo(100L); // Reflection으로 넣은 ID 확인
+		assertThat(dto.id()).isEqualTo(100L);
 		assertThat(dto.type()).isEqualTo(WalletTransactionType.TOPUP_DONE);
 		assertThat(dto.typeName()).isEqualTo("예치금 충전");
 		assertThat(dto.balance()).isEqualTo(50000);
+
+		// 호출 검증
+		verify(paymentTransactionRepository).findAllByMemberIdAndTransactionType(
+			eq(memberId), eq(type), eq(expectedFrom), eq(expectedTo), any(Pageable.class)
+		);
 	}
 
 	@Test
-	@DisplayName("거래 유형이 null이면(전체 조회) null을 Repository에 그대로 전달한다")
-	void getWalletTransactions_withNullType() {
+	@DisplayName("검색 조건(Type, Date)이 null이면 Repository에 null을 그대로 전달한다")
+	void getWalletTransactions_withNullParams() {
 		// given
 		Long memberId = 1L;
 		Page<PaymentTransaction> emptyPage = Page.empty();
 
 		given(paymentTransactionRepository.findAllByMemberIdAndTransactionType(
-			any(), any(), any()))
+			any(), any(), any(), any(), any())) // 인자 개수 5개로 변경됨
 			.willReturn(emptyPage);
 
 		// when
-		useCase.getWalletTransactions(memberId, 0, 10, null);
+		// ✅ Type, From, To 모두 null 전달
+		useCase.getWalletTransactions(memberId, 0, 10, null, null, null);
 
 		// then
 		verify(paymentTransactionRepository).findAllByMemberIdAndTransactionType(
 			eq(memberId),
-			eq(null), // null이 정확히 넘어갔는지 확인
+			eq(null), // Type
+			eq(null), // From
+			eq(null), // To
 			any(Pageable.class)
 		);
 	}

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/in/PaymentControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/in/PaymentControllerTest.java
@@ -347,8 +347,10 @@ class PaymentControllerTest {
 			.andExpect(jsonPath("$.message").value(ErrorType.INSUFFICIENT_BALANCE.getMessage()));
 	}
 
+	// ==================== 지갑 내역 조회 API 테스트 ====================
+
 	@Test
-	@DisplayName("성공: 지갑 거래 내역 조회 시 기본 페이징 파라미터가 적용된다")
+	@DisplayName("성공: 지갑 거래 내역 조회 시 기본 페이징 파라미터와 null 날짜 조건이 적용된다")
 	void getWalletTransactions_success_default() throws Exception {
 		// given
 		Long memberId = 1L;
@@ -358,14 +360,21 @@ class PaymentControllerTest {
 			new PagedResponseDto<>(java.util.Collections.emptyList(),
 				new com.bugzero.rarego.global.response.PageDto(1, 10, 0, 0, false, false));
 
-		// Facade 호출 스텁: page=0, size=10, type=null (기본값)
-		given(paymentFacade.getWalletTransactions(eq(memberId), eq(0), eq(10), isNull()))
-			.willReturn(emptyPageResponse);
+		// Facade 호출 스텁: page=0, size=10, type=null, from=null, to=null (기본값)
+		// 인자가 4개에서 6개로 늘어났으므로 eq(), isNull() 등을 맞춰줘야 함
+		given(paymentFacade.getWalletTransactions(
+			eq(memberId),
+			eq(0),
+			eq(10),
+			isNull(), // type
+			isNull(), // from
+			isNull()  // to
+		)).willReturn(emptyPageResponse);
 
 		// when & then
 		mockMvc.perform(get("/api/v1/payments/me/wallet-transactions")
 				.param("memberId", String.valueOf(memberId))
-				// page, size, transactionType 생략 -> 기본값 적용 확인
+				// page, size, transactionType, from, to 생략 -> 기본값/null 적용 확인
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -374,7 +383,7 @@ class PaymentControllerTest {
 	}
 
 	@Test
-	@DisplayName("성공: 거래 유형(Type)과 페이징 조건을 지정하여 지갑 내역을 조회한다")
+	@DisplayName("성공: 거래 유형(Type)과 날짜 조건(from, to)을 지정하여 지갑 내역을 조회한다")
 	void getWalletTransactions_success_filtering() throws Exception {
 		// given
 		Long memberId = 1L;
@@ -383,21 +392,33 @@ class PaymentControllerTest {
 		com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType type =
 			com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType.TOPUP_DONE;
 
+		// 날짜 조건 설정
+		java.time.LocalDate fromDate = java.time.LocalDate.of(2024, 1, 1);
+		java.time.LocalDate toDate = java.time.LocalDate.of(2024, 1, 31);
+
 		// Mock 응답 데이터 생성
 		PagedResponseDto<WalletTransactionResponseDto> mockResponse =
 			new PagedResponseDto<>(java.util.Collections.emptyList(),
 				new com.bugzero.rarego.global.response.PageDto(page + 1, size, 0, 0, false, false));
 
 		// Facade 호출 스텁: 파라미터가 정확히 전달되는지 검증
-		given(paymentFacade.getWalletTransactions(eq(memberId), eq(page), eq(size), eq(type)))
-			.willReturn(mockResponse);
+		given(paymentFacade.getWalletTransactions(
+			eq(memberId),
+			eq(page),
+			eq(size),
+			eq(type),
+			eq(fromDate), // ★ LocalDate 객체 매칭 확인
+			eq(toDate)    // ★ LocalDate 객체 매칭 확인
+		)).willReturn(mockResponse);
 
 		// when & then
 		mockMvc.perform(get("/api/v1/payments/me/wallet-transactions")
 				.param("memberId", String.valueOf(memberId))
 				.param("page", String.valueOf(page))
 				.param("size", String.valueOf(size))
-				.param("transactionType", type.name()) // Enum -> String 변환 전달
+				.param("transactionType", type.name()) // Enum -> String
+				.param("from", fromDate.toString())    // "2024-01-01"
+				.param("to", toDate.toString())        // "2024-01-31"
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -415,6 +436,22 @@ class PaymentControllerTest {
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isBadRequest()); // Spring Default: MissingServletRequestParameterException
+	}
+
+	@Test
+	@DisplayName("실패: 날짜 포맷이 올바르지 않으면(yyyy-MM-dd 아님) HTTP 400을 반환한다")
+	void getWalletTransactions_fail_invalid_date() throws Exception {
+		// given
+		Long memberId = 1L;
+		String invalidDate = "2024/01/01"; // 잘못된 포맷
+
+		// when & then
+		mockMvc.perform(get("/api/v1/payments/me/wallet-transactions")
+				.param("memberId", String.valueOf(memberId))
+				.param("from", invalidDate)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isBadRequest());
 	}
 
 	// ==================== 정산 내역 조회 API 테스트 ====================

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/in/PaymentControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/in/PaymentControllerTest.java
@@ -416,4 +416,100 @@ class PaymentControllerTest {
 			.andDo(print())
 			.andExpect(status().isBadRequest()); // Spring Default: MissingServletRequestParameterException
 	}
+
+	// ==================== 정산 내역 조회 API 테스트 ====================
+
+	@Test
+	@DisplayName("성공: 정산 내역 조회 시 필수 파라미터(memberId)만 있으면 기본값이 적용된다")
+	void getSettlements_success_default() throws Exception {
+		// given
+		Long memberId = 1L;
+
+		// Mock 응답 생성 (빈 페이지)
+		PagedResponseDto<com.bugzero.rarego.boundedContext.payment.in.dto.SettlementResponseDto> emptyResponse =
+			new PagedResponseDto<>(java.util.Collections.emptyList(),
+				new com.bugzero.rarego.global.response.PageDto(1, 10, 0, 0, false, false));
+
+		// Facade 호출 스텁 검증
+		// page=0, size=10 (기본값)
+		// status=null, from=null, to=null (선택값)
+		given(paymentFacade.getSettlements(eq(memberId), eq(0), eq(10), isNull(), isNull(), isNull()))
+			.willReturn(emptyResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/payments/me/settlements")
+				.param("memberId", String.valueOf(memberId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
+			.andExpect(jsonPath("$.data.data").isArray());
+	}
+
+	@Test
+	@DisplayName("성공: 날짜(ISO Date)와 상태 조건을 포함하여 정산 내역을 조회한다")
+	void getSettlements_success_filtering() throws Exception {
+		// given
+		Long memberId = 1L;
+		int page = 0;
+		int size = 20;
+		com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus status =
+			com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus.DONE;
+
+		// ✅ [핵심] LocalDate 사용 (Controller가 LocalDate를 받음)
+		java.time.LocalDate fromDate = java.time.LocalDate.of(2024, 1, 1);
+		java.time.LocalDate toDate = java.time.LocalDate.of(2024, 1, 31);
+
+		// 요청 파라미터용 String ("2024-01-01")
+		String fromStr = fromDate.toString();
+		String toStr = toDate.toString();
+
+		// Mock 응답 생성
+		PagedResponseDto<com.bugzero.rarego.boundedContext.payment.in.dto.SettlementResponseDto> mockResponse =
+			new PagedResponseDto<>(java.util.Collections.emptyList(),
+				new com.bugzero.rarego.global.response.PageDto(1, size, 0, 0, false, false));
+
+		// Facade 호출 스텁 검증
+		// Controller가 String("2024-01-01")을 받아서 -> LocalDate 객체로 변환하여 Facade에 넘김
+		given(paymentFacade.getSettlements(
+			eq(memberId),
+			eq(page),
+			eq(size),
+			eq(status),
+			eq(fromDate), // ★ LocalDate 객체로 매칭 확인
+			eq(toDate)    // ★ LocalDate 객체로 매칭 확인
+		)).willReturn(mockResponse);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/payments/me/settlements")
+				.param("memberId", String.valueOf(memberId))
+				.param("page", String.valueOf(page))
+				.param("size", String.valueOf(size))
+				.param("status", status.name()) // "DONE"
+				.param("from", fromStr)         // "2024-01-01" (문자열 전송)
+				.param("to", toStr)             // "2024-01-31" (문자열 전송)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()));
+	}
+
+	@Test
+	@DisplayName("실패: 날짜 포맷이 올바르지 않으면(yyyy-MM-dd 아님) HTTP 400을 반환한다")
+	void getSettlements_fail_invalid_date_format() throws Exception {
+		// given
+		Long memberId = 1L;
+
+		// ISO.DATE 형식이 아닌 잘못된 포맷
+		String invalidDate = "2024/01/01";
+
+		// when & then
+		// Facade까지 가지 않고 Spring MVC 레벨에서 바인딩 에러 발생
+		mockMvc.perform(get("/api/v1/payments/me/settlements")
+				.param("memberId", String.valueOf(memberId))
+				.param("from", invalidDate)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isBadRequest()); // 400 Bad Request
+	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #100

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->
<img width="763" height="926" alt="image" src="https://github.com/user-attachments/assets/5e5f458e-5360-4281-ad83-bd806125cd28" />

- [ ] 정산 내역 조회 api 구현
- [ ] 테스트 코드 작성
- [ ] 지갑 거래 내역 조회 api 리팩토링

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- 정산 내역 조회 api에 조회 기간 파라미터가 있어 지갑 거래 내역 조회에도 추가했습니다.
- 정산 내역 조회 시 seller 검증이 필요한데 MemberPriciple을 이용하면 role을 얻을 수 있어 추후 리팩토링 과정에서 구현하겠습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
5분
