### PR TITLE
[FEAT/member] ReplicaMember 생성 연동 (payment, auction)

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacade.java
@@ -33,9 +33,9 @@ import com.bugzero.rarego.shared.auction.dto.BidLogResponseDto;
 import com.bugzero.rarego.shared.auction.dto.BidResponseDto;
 import com.bugzero.rarego.shared.auction.dto.MyBidResponseDto;
 import com.bugzero.rarego.shared.auction.dto.MySaleResponseDto;
+import com.bugzero.rarego.shared.member.domain.MemberDto;
 
 import lombok.RequiredArgsConstructor;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -50,6 +50,7 @@ public class AuctionFacade {
 	private final AuctionRepository auctionRepository;
 	private final ProductRepository productRepository;
 	private final AuctionOrderRepository auctionOrderRepository;
+	private final AuctionSyncMemberUseCase auctionSyncMemberUseCase;
 
 	@Transactional
 	public SuccessResponseDto<BidResponseDto> createBid(Long auctionId, Long memberId, int bidAmount) {
@@ -189,4 +190,10 @@ public class AuctionFacade {
 				return auctionRepository.findAllByProductIdIn(productIds, pageable);
 		}
 	}
+	//
+	@Transactional
+	public AuctionMember syncMember(MemberDto member) {
+		return auctionSyncMemberUseCase.syncMember(member);
+	}
+
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCase.java
@@ -1,0 +1,69 @@
+package com.bugzero.rarego.boundedContext.auction.app;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionMember;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionMemberRepository;
+import com.bugzero.rarego.shared.member.domain.MemberDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class AuctionSyncMemberUseCase {
+
+	private final AuctionMemberRepository auctionMemberRepository;
+
+	public AuctionMember syncMember(MemberDto member) {
+
+		// 신규 가입인지 확인
+		boolean isNew = !auctionMemberRepository.existsById(member.id());
+
+		Optional<AuctionMember> existedOpt = auctionMemberRepository.findById(member.id());
+
+		if (existedOpt.isPresent()) {
+			AuctionMember existed = existedOpt.get();
+
+			// 지연된 이벤트 (현재 updatedAt과 비교 후 느리면) 무시됨
+			if (existed.getUpdatedAt() != null
+				&& member.updatedAt() != null
+				&& !member.updatedAt().isAfter(existed.getUpdatedAt())) {
+
+				log.info("[SKIP] AuctionMember sync 중 이벤트 지연 무시됨. id={}, existedUpdatedAt={}, eventUpdatedAt={}",
+					member.id(), existed.getUpdatedAt(), member.updatedAt());
+				return existed; // 스킵
+			}
+		}
+
+		/**
+		 여기부터는 최신 이벤트일 때만 진행
+		 수정 시 내부적으로 merge로 동작
+		 신규 가입 시 새 객체 반환
+		 **/
+
+		AuctionMember saved =
+			AuctionMember.builder()
+				.id(member.id())
+				.publicId(member.publicId())
+				.email(member.email())
+				.nickname(member.nickname())
+				.intro(member.intro())
+				.address(member.address())
+				.addressDetail(member.addressDetail())
+				.zipCode(member.zipCode())
+				.contactPhone(member.contactPhone())
+				.realName(member.realName())
+				.createdAt(member.createdAt())
+				.updatedAt(member.updatedAt())
+				.deleted(member.deleted())
+				.build();
+		auctionMemberRepository.save(saved);
+		return saved;
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCase.java
@@ -22,11 +22,11 @@ public class AuctionSyncMemberUseCase {
 
 	public AuctionMember syncMember(MemberDto member) {
 
-		// 신규 가입인지 확인
-		boolean isNew = !auctionMemberRepository.existsById(member.id());
-
 		Optional<AuctionMember> existedOpt = auctionMemberRepository.findById(member.id());
 
+		/**
+		 * 이미 존재하는 객체 업데이트
+		 */
 		if (existedOpt.isPresent()) {
 			AuctionMember existed = existedOpt.get();
 
@@ -39,12 +39,13 @@ public class AuctionSyncMemberUseCase {
 					member.id(), existed.getUpdatedAt(), member.updatedAt());
 				return existed; // 스킵
 			}
+
+			existed.updateFrom(member);
+			return existed;
 		}
 
 		/**
-		 여기부터는 최신 이벤트일 때만 진행
-		 수정 시 내부적으로 merge로 동작
-		 신규 가입 시 새 객체 반환
+		 여기부터는 신규 가입일 때만 진행
 		 **/
 
 		AuctionMember saved =

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/in/AuctionEventListener.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/in/AuctionEventListener.java
@@ -1,12 +1,20 @@
 package com.bugzero.rarego.boundedContext.auction.in;
 
-import com.bugzero.rarego.boundedContext.auction.domain.event.AuctionCreatedEvent;
-import com.bugzero.rarego.boundedContext.auction.domain.event.AuctionUpdatedEvent;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import static org.springframework.transaction.annotation.Propagation.*;
+import static org.springframework.transaction.event.TransactionPhase.*;
+
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.bugzero.rarego.boundedContext.auction.app.AuctionFacade;
+import com.bugzero.rarego.boundedContext.auction.domain.event.AuctionCreatedEvent;
+import com.bugzero.rarego.boundedContext.auction.domain.event.AuctionUpdatedEvent;
+import com.bugzero.rarego.shared.member.event.MemberJoinedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 경매 생성/수정 시 자동으로 정산 작업을 예약
@@ -16,38 +24,46 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 public class AuctionEventListener {
 
-    private final AuctionScheduler scheduler;
+	private final AuctionScheduler scheduler;
+	private final AuctionFacade auctionFacade;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onAuctionCreated(AuctionCreatedEvent event) {
-        try {
-            if (event == null || event.auctionId() == null || event.endTime() == null) {
-                log.error("유효하지 않은 AuctionCreatedEvent: {}", event);
-                return;
-            }
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onAuctionCreated(AuctionCreatedEvent event) {
+		try {
+			if (event == null || event.auctionId() == null || event.endTime() == null) {
+				log.error("유효하지 않은 AuctionCreatedEvent: {}", event);
+				return;
+			}
 
-            log.info("경매 생성 이벤트 수신 - auctionId: {}", event.auctionId());
-            scheduler.scheduleSettlement(event.auctionId(), event.endTime());
+			log.info("경매 생성 이벤트 수신 - auctionId: {}", event.auctionId());
+			scheduler.scheduleSettlement(event.auctionId(), event.endTime());
 
-        } catch (Exception e) {
-            log.error("경매 {} 생성 이벤트 처리 실패", event.auctionId(), e);
-        }
-    }
+		} catch (Exception e) {
+			log.error("경매 {} 생성 이벤트 처리 실패", event.auctionId(), e);
+		}
+	}
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onAuctionUpdated(AuctionUpdatedEvent event) {
-        try {
-            if (event == null || event.auctionId() == null || event.newEndTime() == null) {
-                log.error("유효하지 않은 AuctionUpdatedEvent: {}", event);
-                return;
-            }
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onAuctionUpdated(AuctionUpdatedEvent event) {
+		try {
+			if (event == null || event.auctionId() == null || event.newEndTime() == null) {
+				log.error("유효하지 않은 AuctionUpdatedEvent: {}", event);
+				return;
+			}
 
-            log.info("경매 수정 이벤트 수신 - auctionId: {}", event.auctionId());
-            scheduler.cancelSchedule(event.auctionId());
-            scheduler.scheduleSettlement(event.auctionId(), event.newEndTime());
+			log.info("경매 수정 이벤트 수신 - auctionId: {}", event.auctionId());
+			scheduler.cancelSchedule(event.auctionId());
+			scheduler.scheduleSettlement(event.auctionId(), event.newEndTime());
 
-        } catch (Exception e) {
-            log.error("경매 {} 수정 이벤트 처리 실패", event.auctionId(), e);
-        }
-    }
+		} catch (Exception e) {
+			log.error("경매 {} 수정 이벤트 처리 실패", event.auctionId(), e);
+		}
+	}
+
+	@TransactionalEventListener(phase = AFTER_COMMIT)
+	@Transactional(propagation = REQUIRES_NEW)
+	public void onMemberCreated(MemberJoinedEvent event) {
+		auctionFacade.syncMember(event.memberDto());
+	}
+
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentFacade.java
@@ -1,7 +1,9 @@
 package com.bugzero.rarego.boundedContext.payment.app;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
 import com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType;
 import com.bugzero.rarego.boundedContext.payment.in.dto.AuctionFinalPaymentRequestDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.AuctionFinalPaymentResponseDto;
@@ -11,6 +13,7 @@ import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.PaymentRequestResponseDto;
 import com.bugzero.rarego.boundedContext.payment.in.dto.WalletTransactionResponseDto;
 import com.bugzero.rarego.global.response.PagedResponseDto;
+import com.bugzero.rarego.shared.member.domain.MemberDto;
 import com.bugzero.rarego.shared.payment.dto.DepositHoldRequestDto;
 import com.bugzero.rarego.shared.payment.dto.DepositHoldResponseDto;
 
@@ -26,6 +29,7 @@ public class PaymentFacade {
 	private final PaymentProcessSettlementUseCase paymentProcessSettlementUseCase;
 	private final PaymentAuctionFinalUseCase paymentAuctionFinalUseCase;
 	private final PaymentGetWalletTransactionsUseCase paymentGetWalletTransactionsUseCase;
+	private final PaymentSyncMemberUseCase paymentSyncMemberUseCase;
 
 	/**
 	 * 보증금 홀딩
@@ -78,4 +82,13 @@ public class PaymentFacade {
 		return paymentGetWalletTransactionsUseCase.getWalletTransactions(memberId, page, size, transactionType);
 
 	}
+
+	/**
+	 * PaymentMember 동기화
+	 */
+	@Transactional
+	public PaymentMember syncMember(MemberDto member) {
+		return paymentSyncMemberUseCase.syncMember(member);
+	}
+
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCase.java
@@ -1,0 +1,69 @@
+package com.bugzero.rarego.boundedContext.payment.app;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
+import com.bugzero.rarego.shared.member.domain.MemberDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class PaymentSyncMemberUseCase {
+
+	private final PaymentMemberRepository paymentMemberRepository;
+
+	public PaymentMember syncMember(MemberDto member) {
+
+		// 신규 가입인지 확인
+		boolean isNew = !paymentMemberRepository.existsById(member.id());
+
+		Optional<PaymentMember> existedOpt = paymentMemberRepository.findById(member.id());
+
+		if (existedOpt.isPresent()) {
+			PaymentMember existed = existedOpt.get();
+
+			// 지연된 이벤트 (현재 updatedAt과 비교 후 느리면) 무시됨
+			if (existed.getUpdatedAt() != null
+				&& member.updatedAt() != null
+				&& !member.updatedAt().isAfter(existed.getUpdatedAt())) {
+
+				log.info("[SKIP] paymentMember sync 중 이벤트 지연 무시됨. id={}, existedUpdatedAt={}, eventUpdatedAt={}",
+					member.id(), existed.getUpdatedAt(), member.updatedAt());
+				return existed; // 스킵
+			}
+		}
+
+		/**
+		 여기부터는 최신 이벤트일 때만 진행
+		 수정 시 내부적으로 merge로 동작
+		 신규 가입 시 새 객체 반환
+		 **/
+
+		PaymentMember saved =
+			PaymentMember.builder()
+				.id(member.id())
+				.publicId(member.publicId())
+				.email(member.email())
+				.nickname(member.nickname())
+				.intro(member.intro())
+				.address(member.address())
+				.addressDetail(member.addressDetail())
+				.zipCode(member.zipCode())
+				.contactPhone(member.contactPhone())
+				.realName(member.realName())
+				.createdAt(member.createdAt())
+				.updatedAt(member.updatedAt())
+				.deleted(member.deleted())
+				.build();
+		paymentMemberRepository.save(saved);
+		return saved;
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCase.java
@@ -27,7 +27,9 @@ public class PaymentSyncMemberUseCase {
 
 		Optional<PaymentMember> existedOpt = paymentMemberRepository.findById(member.id());
 
-		// 1) 기존 객체에 업데이트
+		/**
+		 * 기존 객체에 업데이트 로직
+		 */
 		if (existedOpt.isPresent()) {
 			PaymentMember existed = existedOpt.get();
 
@@ -49,7 +51,6 @@ public class PaymentSyncMemberUseCase {
 		 여기부터는 신규 가입일 때만 진행
 		 **/
 
-		// 2) 새로운 객체 생성
 		// 1. 객체 생성
 		PaymentMember saved =
 			PaymentMember.builder()

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentEventListener.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentEventListener.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.bugzero.rarego.boundedContext.payment.app.PaymentFacade;
 import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
+import com.bugzero.rarego.shared.member.event.MemberJoinedEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,5 +26,11 @@ public class PaymentEventListener {
     public void handle(AuctionEndedEvent event) {
         log.info("경매 종료 이벤트 수신: auctionId={}, winnerId={}", event.auctionId(), event.winnerId());
         paymentFacade.releaseDeposits(event.auctionId(), event.winnerId());
+    }
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    @Transactional(propagation = REQUIRES_NEW)
+    public void onMemberCreated(MemberJoinedEvent event) {
+        paymentFacade.syncMember(event.memberDto());
     }
 }

--- a/src/main/java/com/bugzero/rarego/shared/member/domain/BaseMember.java
+++ b/src/main/java/com/bugzero/rarego/shared/member/domain/BaseMember.java
@@ -43,4 +43,16 @@ public abstract class BaseMember extends BaseEntity {
 
 	@Column(name = "real_name", length = 10)
 	private String realName;
+
+	protected void updateFrom(MemberDto member) {
+		this.publicId = member.publicId();
+		this.email = member.email();
+		this.nickname = member.nickname();
+		this.intro = member.intro();
+		this.address = member.address();
+		this.addressDetail = member.addressDetail();
+		this.zipCode = member.zipCode();
+		this.contactPhone = member.contactPhone();
+		this.realName = member.realName();
+	}
 }

--- a/src/main/java/com/bugzero/rarego/shared/member/domain/ReplicaMember.java
+++ b/src/main/java/com/bugzero/rarego/shared/member/domain/ReplicaMember.java
@@ -20,4 +20,5 @@ public abstract class ReplicaMember extends BaseMember {
 	private LocalDateTime createdAt;
 
 	private LocalDateTime updatedAt;
+
 }

--- a/src/main/java/com/bugzero/rarego/shared/member/domain/ReplicaMember.java
+++ b/src/main/java/com/bugzero/rarego/shared/member/domain/ReplicaMember.java
@@ -21,4 +21,12 @@ public abstract class ReplicaMember extends BaseMember {
 
 	private LocalDateTime updatedAt;
 
+	@Override
+	public void updateFrom(MemberDto member) {
+		super.updateFrom(member);
+		this.createdAt = member.createdAt();
+		this.updatedAt = member.updatedAt();
+		this.deleted = member.deleted();
+	}
+
 }

--- a/src/main/java/com/bugzero/rarego/shared/member/event/MemberJoinedEvent.java
+++ b/src/main/java/com/bugzero/rarego/shared/member/event/MemberJoinedEvent.java
@@ -2,11 +2,7 @@ package com.bugzero.rarego.shared.member.event;
 
 import com.bugzero.rarego.shared.member.domain.MemberDto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class MemberJoinedEvent {
-	private final MemberDto member;
+public record MemberJoinedEvent(
+	MemberDto memberDto
+) {
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCaseTest.java
@@ -1,0 +1,106 @@
+package com.bugzero.rarego.boundedContext.auction.app;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionMember;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionMemberRepository;
+import com.bugzero.rarego.shared.member.domain.MemberDto;
+
+@ExtendWith(MockitoExtension.class)
+class AuctionSyncMemberUseCaseTest {
+
+	@Mock
+	private AuctionMemberRepository auctionMemberRepository;
+
+	@InjectMocks
+	private AuctionSyncMemberUseCase auctionSyncMemberUseCase;
+
+	@Test
+	@DisplayName("존재하는 것보다 늦은 변경은 무시")
+	void syncMember_SkipDelayedEvent() {
+		// given
+		LocalDateTime existedUpdatedAt = LocalDateTime.now();
+		AuctionMember existed = AuctionMember.builder()
+			.id(1L)
+			.updatedAt(existedUpdatedAt)
+			.build();
+
+		MemberDto member = new MemberDto(
+			1L,
+			"public-id",
+			"user@example.com",
+			"nick",
+			"intro",
+			"address",
+			"address detail",
+			"12345",
+			"01000000000",
+			"real name",
+			existedUpdatedAt.minusDays(1),
+			existedUpdatedAt.minusMinutes(1),
+			false
+		);
+
+		given(auctionMemberRepository.findById(1L)).willReturn(Optional.of(existed));
+
+		// when
+		AuctionMember result = auctionSyncMemberUseCase.syncMember(member);
+
+		// then
+		assertThat(result).isSameAs(existed);
+		verify(auctionMemberRepository, never()).save(any(AuctionMember.class));
+	}
+
+	@Test
+	@DisplayName("존재하는 것보다 새로운 업데이트는 추가")
+	void syncMember_SaveWhenNewerEvent() {
+		// given
+		LocalDateTime existedUpdatedAt = LocalDateTime.now().minusHours(2);
+		AuctionMember existed = AuctionMember.builder()
+			.id(1L)
+			.updatedAt(existedUpdatedAt)
+			.build();
+
+		LocalDateTime eventUpdatedAt = LocalDateTime.now();
+		MemberDto member = new MemberDto(
+			1L,
+			"public-id",
+			"user@example.com",
+			"nick",
+			"intro",
+			"address",
+			"address detail",
+			"12345",
+			"01000000000",
+			"real name",
+			eventUpdatedAt.minusDays(1),
+			eventUpdatedAt,
+			false
+		);
+
+		given(auctionMemberRepository.findById(1L)).willReturn(Optional.of(existed));
+		given(auctionMemberRepository.save(any(AuctionMember.class)))
+			.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		AuctionMember result = auctionSyncMemberUseCase.syncMember(member);
+
+		// then
+		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result.getUpdatedAt()).isEqualTo(eventUpdatedAt);
+		assertThat(result.getEmail()).isEqualTo("user@example.com");
+		verify(auctionMemberRepository).save(any(AuctionMember.class));
+	}
+}

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCaseTest.java
@@ -28,7 +28,7 @@ class AuctionSyncMemberUseCaseTest {
 	private AuctionSyncMemberUseCase auctionSyncMemberUseCase;
 
 	@Test
-	@DisplayName("존재하는 것보다 늦은 변경은 무시")
+	@DisplayName("replica에서 업데이트 된 날짜보다 늦은 날짜의 수정 요청은 무시")
 	void syncMember_SkipDelayedEvent() {
 		// given
 		LocalDateTime existedUpdatedAt = LocalDateTime.now();
@@ -64,7 +64,7 @@ class AuctionSyncMemberUseCaseTest {
 	}
 
 	@Test
-	@DisplayName("존재하는 것보다 새로운 업데이트는 반영")
+	@DisplayName("replica에서 업데이트 된 날짜보다 새로운 업데이트는 반영")
 	void syncMember_UpdateWhenNewerEvent() {
 		// given
 		LocalDateTime existedUpdatedAt = LocalDateTime.now().minusHours(2);

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSyncMemberUseCaseTest.java
@@ -64,8 +64,8 @@ class AuctionSyncMemberUseCaseTest {
 	}
 
 	@Test
-	@DisplayName("존재하는 것보다 새로운 업데이트는 추가")
-	void syncMember_SaveWhenNewerEvent() {
+	@DisplayName("존재하는 것보다 새로운 업데이트는 반영")
+	void syncMember_UpdateWhenNewerEvent() {
 		// given
 		LocalDateTime existedUpdatedAt = LocalDateTime.now().minusHours(2);
 		AuctionMember existed = AuctionMember.builder()
@@ -91,16 +91,13 @@ class AuctionSyncMemberUseCaseTest {
 		);
 
 		given(auctionMemberRepository.findById(1L)).willReturn(Optional.of(existed));
-		given(auctionMemberRepository.save(any(AuctionMember.class)))
-			.willAnswer(invocation -> invocation.getArgument(0));
-
 		// when
 		AuctionMember result = auctionSyncMemberUseCase.syncMember(member);
 
 		// then
-		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result).isSameAs(existed);
 		assertThat(result.getUpdatedAt()).isEqualTo(eventUpdatedAt);
 		assertThat(result.getEmail()).isEqualTo("user@example.com");
-		verify(auctionMemberRepository).save(any(AuctionMember.class));
+		verify(auctionMemberRepository, never()).save(any(AuctionMember.class));
 	}
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCaseTest.java
@@ -28,7 +28,7 @@ class PaymentSyncMemberUseCaseTest {
 	private PaymentSyncMemberUseCase paymentSyncMemberUseCase;
 
 	@Test
-	@DisplayName("존재하는것보다 늦은 변경은 무시")
+	@DisplayName("replica에서 이미 업데이트 된 날짜보다 늦은 변경은 무시")
 	void syncMember_SkipDelayedEvent() {
 		// given
 		LocalDateTime existedUpdatedAt = LocalDateTime.now();
@@ -64,7 +64,7 @@ class PaymentSyncMemberUseCaseTest {
 	}
 
 	@Test
-	@DisplayName("존재하는 것보다 새로운 업데이트는 반영")
+	@DisplayName("replica에서 이미 업데이트 된 날짜보다 새로운 업데이트는 반영")
 	void syncMember_UpdateWhenNewerEvent() {
 		// given
 		LocalDateTime existedUpdatedAt = LocalDateTime.now().minusHours(2);

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCaseTest.java
@@ -64,8 +64,8 @@ class PaymentSyncMemberUseCaseTest {
 	}
 
 	@Test
-	@DisplayName("존재하는 것보다 빠른 변경은 추가")
-	void syncMember_SaveWhenNewerEvent() {
+	@DisplayName("존재하는 것보다 새로운 업데이트는 반영")
+	void syncMember_UpdateWhenNewerEvent() {
 		// given
 		LocalDateTime existedUpdatedAt = LocalDateTime.now().minusHours(2);
 		PaymentMember existed = PaymentMember.builder()
@@ -91,16 +91,13 @@ class PaymentSyncMemberUseCaseTest {
 		);
 
 		given(paymentMemberRepository.findById(1L)).willReturn(Optional.of(existed));
-		given(paymentMemberRepository.save(any(PaymentMember.class)))
-			.willAnswer(invocation -> invocation.getArgument(0));
-
 		// when
 		PaymentMember result = paymentSyncMemberUseCase.syncMember(member);
 
 		// then
-		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result).isSameAs(existed);
 		assertThat(result.getUpdatedAt()).isEqualTo(eventUpdatedAt);
 		assertThat(result.getEmail()).isEqualTo("user@example.com");
-		verify(paymentMemberRepository).save(any(PaymentMember.class));
+		verify(paymentMemberRepository, never()).save(any(PaymentMember.class));
 	}
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSyncMemberUseCaseTest.java
@@ -1,0 +1,106 @@
+package com.bugzero.rarego.boundedContext.payment.app;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
+import com.bugzero.rarego.boundedContext.payment.out.PaymentMemberRepository;
+import com.bugzero.rarego.shared.member.domain.MemberDto;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentSyncMemberUseCaseTest {
+
+	@Mock
+	private PaymentMemberRepository paymentMemberRepository;
+
+	@InjectMocks
+	private PaymentSyncMemberUseCase paymentSyncMemberUseCase;
+
+	@Test
+	@DisplayName("존재하는것보다 늦은 변경은 무시")
+	void syncMember_SkipDelayedEvent() {
+		// given
+		LocalDateTime existedUpdatedAt = LocalDateTime.now();
+		PaymentMember existed = PaymentMember.builder()
+			.id(1L)
+			.updatedAt(existedUpdatedAt)
+			.build();
+
+		MemberDto member = new MemberDto(
+			1L,
+			"public-id",
+			"user@example.com",
+			"nick",
+			"intro",
+			"address",
+			"address detail",
+			"12345",
+			"01000000000",
+			"real name",
+			existedUpdatedAt.minusDays(1),
+			existedUpdatedAt.minusMinutes(1),
+			false
+		);
+
+		given(paymentMemberRepository.findById(1L)).willReturn(Optional.of(existed));
+
+		// when
+		PaymentMember result = paymentSyncMemberUseCase.syncMember(member);
+
+		// then
+		assertThat(result).isSameAs(existed);
+		verify(paymentMemberRepository, never()).save(any(PaymentMember.class));
+	}
+
+	@Test
+	@DisplayName("존재하는 것보다 빠른 변경은 추가")
+	void syncMember_SaveWhenNewerEvent() {
+		// given
+		LocalDateTime existedUpdatedAt = LocalDateTime.now().minusHours(2);
+		PaymentMember existed = PaymentMember.builder()
+			.id(1L)
+			.updatedAt(existedUpdatedAt)
+			.build();
+
+		LocalDateTime eventUpdatedAt = LocalDateTime.now();
+		MemberDto member = new MemberDto(
+			1L,
+			"public-id",
+			"user@example.com",
+			"nick",
+			"intro",
+			"address",
+			"address detail",
+			"12345",
+			"01000000000",
+			"real name",
+			eventUpdatedAt.minusDays(1),
+			eventUpdatedAt,
+			false
+		);
+
+		given(paymentMemberRepository.findById(1L)).willReturn(Optional.of(existed));
+		given(paymentMemberRepository.save(any(PaymentMember.class)))
+			.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		PaymentMember result = paymentSyncMemberUseCase.syncMember(member);
+
+		// then
+		assertThat(result.getId()).isEqualTo(1L);
+		assertThat(result.getUpdatedAt()).isEqualTo(eventUpdatedAt);
+		assertThat(result.getEmail()).isEqualTo("user@example.com");
+		verify(paymentMemberRepository).save(any(PaymentMember.class));
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #102 

## 🚀 작업 내용

- [x] paymentEventListener, auctionEventListner를 활용해 memberJoinedEvent에서 새 ReplicaMember를 생성합니다.
- [x] SyncMemberUseCase: 수정과 같은 메서드를 전제로, id가 존재하면 db에서 update, 새로운 객체면 db에서 생성 처리를 합니다.
- [x] 이벤트가 늦거나 밀려 최신 업데이트보다 updatedAt이 늦다면 해당 이벤트를 무시합니다.

## 🔍 리뷰 요청 사항 및 공유자료
Google 로그인: http://localhost:8080/oauth2/authorization/google
Kakao 로그인: http://localhost:8080/oauth2/authorization/kakao
Naver 로그인: http://localhost:8080/oauth2/authorization/naver

- 회원가입 후 paymentMember, auctionMember가 생성되고, 토큰이 필요한 메서드를 작동할 수 있는지 확인 부탁드립니다.
- 컨벤션에 어긋나는 파일명, 형식이 없는지 확인 부탁드립니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분 +
