### PR TITLE
[FIX/infra] 도커 네트워크 불일치 문제

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     # 데이터 영속성 설정 (컨테이너 삭제돼도 데이터 보존)
     volumes:
       - db_data:/var/lib/mysql
+    networks:
+      - rarego-network
 
     # 컨테이너 상태 체크 (Spring Boot의 depends_on 조건 등으로 활용 가능)
     # DB가 완전히 부팅되어 쿼리를 받을 수 있는지 주기적으로 확인


### PR DESCRIPTION
# 🐛 버그 수정 PR인 경우

## #️⃣ 연관된 이슈
close: #139 

## 📝 수정 요약
- `Communications link failure` 백엔드와 DB 컨테이너가 서로 다른 도커 네트워크에 있는 문제 수정

- 🚨 문제점
  - `Communications link failure` 백엔드와 DB 컨테이너가 서로 다른 도커 네트워크에 있는 문제 발생
- 🔍 원인 분석
  - `app`: `rarego-network` (외부 네트워크) 소속
  - `db`: 기본 도커 네트워크 소속
- 💡 해결 방법
  - `docker-compose.yml`에서 `db` 서비스도 `rarego-network`에 소속되도록 수정


## 🛠️ PR 유형
- [x] 버그 수정


## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
1분