### PR TITLE
[FEAT/product] member 데이터 동기화 기능 구현

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/product/app/ProductFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/app/ProductFacade.java
@@ -2,6 +2,8 @@ package com.bugzero.rarego.boundedContext.product.app;
 
 import org.springframework.stereotype.Service;
 
+import com.bugzero.rarego.boundedContext.product.domain.ProductMember;
+import com.bugzero.rarego.shared.member.domain.MemberDto;
 import com.bugzero.rarego.shared.product.dto.ProductInspectionRequestDto;
 import com.bugzero.rarego.shared.product.dto.ProductInspectionResponseDto;
 import com.bugzero.rarego.shared.product.dto.ProductRequestDto;
@@ -17,6 +19,7 @@ public class ProductFacade {
 
 	private final ProductCreateProductUseCase productCreateProductUseCase;
 	private final ProductCreateInspectionUseCase productCreateInspectionUseCase;
+	private final ProductSyncMemberUseCase productSyncMemberUseCase;
 
 	public ProductResponseDto createProduct(String memberUUID, ProductRequestDto dto) {
 		return productCreateProductUseCase.createProduct(memberUUID, dto);
@@ -29,5 +32,9 @@ public class ProductFacade {
 
 	public ProductUpdateResponseDto updateProduct(String publicId, Long productId, ProductUpdateDto productUpdateDto) {
 		return productUpdateProductUseCase.updateProduct(publicId, productId, productUpdateDto);
+	}
+
+	public ProductMember syncMember(MemberDto member) {
+		return productSyncMemberUseCase.syncMember(member);
 	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/app/ProductSyncMemberUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/app/ProductSyncMemberUseCase.java
@@ -1,0 +1,69 @@
+package com.bugzero.rarego.boundedContext.product.app;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bugzero.rarego.boundedContext.product.domain.ProductMember;
+import com.bugzero.rarego.boundedContext.product.out.ProductMemberRepository;
+import com.bugzero.rarego.shared.member.domain.MemberDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ProductSyncMemberUseCase {
+	private final ProductMemberRepository productMemberRepository;
+
+	public ProductMember syncMember(MemberDto member) {
+
+		Optional<ProductMember> existedOpt = productMemberRepository.findById(member.id());
+
+		/**
+		 * 이미 존재하는 객체 업데이트
+		 */
+		if (existedOpt.isPresent()) {
+			ProductMember existed = existedOpt.get();
+
+			// 지연된 이벤트 (현재 updatedAt과 비교 후 느리면) 무시됨
+			if (existed.getUpdatedAt() != null
+				&& member.updatedAt() != null
+				&& !member.updatedAt().isAfter(existed.getUpdatedAt())) {
+
+				log.info("[SKIP] AuctionMember sync 중 이벤트 지연 무시됨. id={}, existedUpdatedAt={}, eventUpdatedAt={}",
+					member.id(), existed.getUpdatedAt(), member.updatedAt());
+				return existed; // 스킵
+			}
+
+			existed.updateFrom(member);
+			return existed;
+		}
+
+		/**
+		 여기부터는 신규 가입일 때만 진행
+		 **/
+
+		ProductMember saved =
+			ProductMember.builder()
+				.id(member.id())
+				.publicId(member.publicId())
+				.email(member.email())
+				.nickname(member.nickname())
+				.intro(member.intro())
+				.address(member.address())
+				.addressDetail(member.addressDetail())
+				.zipCode(member.zipCode())
+				.contactPhone(member.contactPhone())
+				.realName(member.realName())
+				.createdAt(member.createdAt())
+				.updatedAt(member.updatedAt())
+				.deleted(member.deleted())
+				.build();
+		productMemberRepository.save(saved);
+		return saved;
+	}
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/in/ProductDataInit.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/in/ProductDataInit.java
@@ -1,8 +1,5 @@
 package com.bugzero.rarego.boundedContext.product.in;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -11,7 +8,6 @@ import com.bugzero.rarego.boundedContext.product.domain.Category;
 import com.bugzero.rarego.boundedContext.product.domain.InspectionStatus;
 import com.bugzero.rarego.boundedContext.product.domain.Product;
 import com.bugzero.rarego.boundedContext.product.domain.ProductCondition;
-import com.bugzero.rarego.boundedContext.product.domain.ProductMember;
 import com.bugzero.rarego.boundedContext.product.out.ProductMemberRepository;
 import com.bugzero.rarego.boundedContext.product.out.ProductRepository;
 
@@ -28,26 +24,6 @@ public class ProductDataInit implements CommandLineRunner {
 
 	@Override
 	public void run(String... args) throws Exception {
-		// ProductMember 초기 데이터
-		ProductMember admin = ProductMember.builder()
-			.id(1L)
-			.publicId(UUID.randomUUID().toString())
-			.email("test1@bugzero.com")
-			.nickname("테스트유저")
-			.createdAt(LocalDateTime.now())
-			.updatedAt(LocalDateTime.now())
-			.build();
-		productMemberRepository.save(admin);
-
-		ProductMember member = ProductMember.builder()
-			.id(2L)
-			.publicId(UUID.randomUUID().toString())
-			.email("test2@bugzero.com")
-			.nickname("일반회원")
-			.createdAt(LocalDateTime.now())
-			.updatedAt(LocalDateTime.now())
-			.build();
-		productMemberRepository.save(member);
 
 		//ProductMember 초기 데이터
 		createProduct(1L, "다크나이트");

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/in/ProductEventListener.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/in/ProductEventListener.java
@@ -1,0 +1,32 @@
+package com.bugzero.rarego.boundedContext.product.in;
+
+import static org.springframework.transaction.annotation.Propagation.*;
+import static org.springframework.transaction.event.TransactionPhase.*;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.bugzero.rarego.boundedContext.product.app.ProductFacade;
+import com.bugzero.rarego.shared.member.event.MemberJoinedEvent;
+import com.bugzero.rarego.shared.member.event.MemberUpdatedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductEventListener {
+	private final ProductFacade  productFacade;
+
+	@TransactionalEventListener(phase = AFTER_COMMIT)
+	@Transactional(propagation = REQUIRES_NEW)
+	public void onMemberCreated(MemberJoinedEvent event) {
+		productFacade.syncMember(event.memberDto());
+	}
+
+	@TransactionalEventListener(phase = AFTER_COMMIT)
+	@Transactional(propagation = REQUIRES_NEW)
+	public void onMemberUpdated(MemberUpdatedEvent event) {
+		productFacade.syncMember(event.memberDto());
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #111 
## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->
- ProductEventListener
  - onMemberCreated, onMemberCreated 를 통해  SourceMember 데이터에 변경사항이 있을 시 ProductFacade.syncMember 로직이 실행될 수 있도록 함. 
- ProductSyncMemberUseCase
  - 멤버 데이터 동기화 로직 수행 
- [x] 멤버 데이터 원본에 변경사항이 생겼을 시에 ProductMember 데이터 동기화 기능 구현

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- 멤버 데이터가 동기화된것을 확인

<img width="448" height="177" alt="image" src="https://github.com/user-attachments/assets/1b1c5826-e827-4d5d-aa54-dac527c6271d" />

<img width="419" height="188" alt="image" src="https://github.com/user-attachments/assets/a1693c10-7eec-4c3d-a478-1abaeb18d96b" />

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션을 지켰습니다.
- [X] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->