### PR TITLE
[CHORE/infra] CORS 설정

### DIFF
--- a/src/main/java/com/bugzero/rarego/global/config/SecurityConfig.java
+++ b/src/main/java/com/bugzero/rarego/global/config/SecurityConfig.java
@@ -9,6 +9,9 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.bugzero.rarego.global.security.CustomAccessDeniedHandler;
 import com.bugzero.rarego.global.security.CustomAuthenticationEntryPoint;
@@ -16,6 +19,9 @@ import com.bugzero.rarego.boundedContext.auth.app.AuthOAuth2AccountService;
 import com.bugzero.rarego.global.security.CustomOAuth2SuccessHandler;
 import com.bugzero.rarego.global.security.JwtAuthenticationFilter;
 import com.bugzero.rarego.global.security.JwtParser;
+
+import java.util.Arrays;
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
@@ -38,7 +44,6 @@ public class SecurityConfig {
 		AuthOAuth2AccountService authOAuth2AccountService,
 		CustomOAuth2SuccessHandler customOAuth2SuccessHandler) throws Exception {
 		http.authorizeHttpRequests(
-
 				auth -> auth
 					.requestMatchers("/favicon.ico").permitAll()
 					.requestMatchers("/h2-console/**").permitAll()
@@ -52,6 +57,7 @@ public class SecurityConfig {
 					)
 			).csrf(
 				AbstractHttpConfigurer::disable
+			).cors(cors -> cors.configurationSource(corsConfigurationSource())
 			).oauth2Login(oauth2 -> oauth2
 				.userInfoEndpoint(userInfo -> userInfo.userService(authOAuth2AccountService))
 				.successHandler(customOAuth2SuccessHandler)
@@ -65,5 +71,21 @@ public class SecurityConfig {
 			.addFilterBefore(new JwtAuthenticationFilter(jwtParser), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of(
+			"http://localhost:3000",
+			"https://rarego.duckdns.org"
+		));
+		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Cache-Control"));
+		configuration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 server:
   port: 8080
   forward-headers-strategy: native
+  tomcat:
+    relaxed-query-chars: '[,]'
 
 
 spring:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #161 

## 🚀 작업 내용
- [x] localhost:3000 환경에서 API 접근을 허용하도록 `SecurityConfig.java` 수정
- [x] Tomcat 서버 쿼리스트링 직렬화 방식(대괄호 사용)을 지원하기 위해 `relaxed-query-chars` 옵션 활성화

## 🔍 리뷰 요청 사항 및 공유자료
- 로컬 개발 시 프론트엔드(localhost:3000)와 서버 사이의 통신을 위해 `SecurityConfig`에 CORS 허용 설정을 추가했습니다.
- `openapi-fetch` 클라이언트가 페이징 쿼리를 `pageable[page]=0` 형태로 보내는데, Tomcat의 기본 RFC 보안 정책상 대괄호를 차단하여 이를 허용하도록 `application.yml` 설정을 추가했습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
3분