### PR TITLE
[FIX/payment] 거래내역 조회시 사용 가능 및 잔액 조회 로직 개선

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/dto/WalletTransactionResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/dto/WalletTransactionResponseDto.java
@@ -7,27 +7,27 @@ import com.bugzero.rarego.boundedContext.payment.domain.ReferenceType;
 import com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType;
 
 public record WalletTransactionResponseDto(
-	Long id,
-	WalletTransactionType type,
-	String typeName,
-	int balanceDelta,
-	int holdingDelta,
-	int balance,
-	ReferenceType referenceType,
-	Long referenceId,
-	LocalDateTime createdAt
-) {
+		Long id,
+		WalletTransactionType type,
+		String typeName,
+		int balanceDelta,
+		int holdingDelta,
+		int balance,
+		int holdingAmount,
+		ReferenceType referenceType,
+		Long referenceId,
+		LocalDateTime createdAt) {
 	public static WalletTransactionResponseDto from(PaymentTransaction transaction) {
 		return new WalletTransactionResponseDto(
-			transaction.getId(),
-			transaction.getTransactionType(),
-			transaction.getTransactionType().getDescription(),
-			transaction.getBalanceDelta(),
-			transaction.getHoldingDelta(),
-			transaction.getBalanceAfter(),
-			transaction.getReferenceType(),
-			transaction.getReferenceId(),
-			transaction.getCreatedAt()
-		);
+				transaction.getId(),
+				transaction.getTransactionType(),
+				transaction.getTransactionType().getDescription(),
+				transaction.getBalanceDelta(),
+				transaction.getHoldingDelta(),
+				transaction.getBalanceAfter(),
+				transaction.getWallet().getHoldingAmount(),
+				transaction.getReferenceType(),
+				transaction.getReferenceId(),
+				transaction.getCreatedAt());
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #165 

## 🚀 작업 내용
- [x] `WalletTransactionResponseDto`에 `holdingAmount` 필드 추가

<img width="781" height="410" alt="스크린샷 2026-01-22 오후 3 15 45" src="https://github.com/user-attachments/assets/d53c03c1-fd81-486a-a9e4-43866d95207b" />


## 🔍 리뷰 요청 사항 및 공유자료
기존에 UI에 표시할 수 없었던 사용 가능 금액과 현재 보증금으로 인해 동결중인 총 금액을 나타내기 위해 `WalletTransactionResponseDto`에 `holdingAmount` 필드를 추가했습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
1분