### PR TITLE
[FIX/global] 내부 API 통신 에러 핸들링 공통화

### DIFF
--- a/src/main/java/com/bugzero/rarego/global/exception/InternalApiErrorHandler.java
+++ b/src/main/java/com/bugzero/rarego/global/exception/InternalApiErrorHandler.java
@@ -1,0 +1,61 @@
+package com.bugzero.rarego.global.exception;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.global.response.ErrorType;
+import com.bugzero.rarego.global.response.ExceptionResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InternalApiErrorHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public void handle(HttpRequest request, ClientHttpResponse response) throws IOException {
+        String body = new String(response.getBody().readAllBytes());
+
+        log.error("Internal API 호출 실패 - URI: {}, Status: {}, Body: {}",
+                request.getURI(), response.getStatusCode(), body);
+
+        try {
+            ExceptionResponseDto errorResponse = objectMapper.readValue(body, ExceptionResponseDto.class);
+            ErrorType errorType = ErrorType.findByCode(errorResponse.code())
+                    .orElse(ErrorType.INTERNAL_SERVER_ERROR);
+            throw new CustomException(errorType, errorResponse.message());
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Internal API 에러 응답 파싱 실패: {}", e.getMessage());
+            throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR, "내부 서비스 호출 실패: " + body);
+        }
+    }
+
+    public void handleWithDefault(HttpRequest request, ClientHttpResponse response, ErrorType defaultErrorType)
+            throws IOException {
+        String body = new String(response.getBody().readAllBytes());
+
+        log.error("Internal API 호출 실패 - URI: {}, Status: {}, Body: {}",
+                request.getURI(), response.getStatusCode(), body);
+
+        try {
+            ExceptionResponseDto errorResponse = objectMapper.readValue(body, ExceptionResponseDto.class);
+            ErrorType errorType = ErrorType.findByCode(errorResponse.code())
+                    .orElse(defaultErrorType);
+            throw new CustomException(errorType, errorResponse.message());
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Internal API 에러 응답 파싱 실패: {}", e.getMessage());
+            throw new CustomException(defaultErrorType);
+        }
+    }
+}

--- a/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
@@ -1,5 +1,8 @@
 package com.bugzero.rarego.global.response;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -112,4 +115,10 @@ public enum ErrorType {
     private final Integer httpStatus;
     private final int code;
     private final String message;
+
+    public static Optional<ErrorType> findByCode(int code) {
+        return Arrays.stream(values())
+                .filter(type -> type.code == code)
+                .findFirst();
+    }
 }

--- a/src/main/java/com/bugzero/rarego/shared/auction/out/AuctionApiClient.java
+++ b/src/main/java/com/bugzero/rarego/shared/auction/out/AuctionApiClient.java
@@ -35,7 +35,7 @@ public class AuctionApiClient {
                 .body(productAuctionRequestDto)
                 .retrieve()
                 .onStatus(HttpStatusCode::isError,
-                    (req, res) -> errorHandler.handleWithDefault(req, res, ErrorType.AUCTION_CREATE_FAILED))
+                    (httpRequest, httpResponse) -> errorHandler.handleWithDefault(httpRequest, httpResponse, ErrorType.AUCTION_CREATE_FAILED))
                 .body(new ParameterizedTypeReference<>() {
                 });
 

--- a/src/main/java/com/bugzero/rarego/shared/auction/out/AuctionApiClient.java
+++ b/src/main/java/com/bugzero/rarego/shared/auction/out/AuctionApiClient.java
@@ -5,10 +5,12 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
 import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.exception.InternalApiErrorHandler;
 import com.bugzero.rarego.global.response.ErrorType;
 import com.bugzero.rarego.global.response.SuccessResponseDto;
 import com.bugzero.rarego.shared.product.dto.ProductAuctionRequestDto;
@@ -17,8 +19,10 @@ import com.bugzero.rarego.shared.product.dto.ProductAuctionUpdateDto;
 @Service
 public class AuctionApiClient {
     private final RestClient restClient;
+    private final InternalApiErrorHandler errorHandler;
 
-    public AuctionApiClient(@Value("${custom.global.internalBackUrl}") String internalBackUrl) {
+    public AuctionApiClient(@Value("${custom.global.internalBackUrl}") String internalBackUrl, InternalApiErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
         this.restClient = RestClient.builder()
                 .baseUrl(internalBackUrl + "/api/v1/internal/auctions")
                 .build();
@@ -27,34 +31,32 @@ public class AuctionApiClient {
     public Long createAuction(Long productId, String publicId, ProductAuctionRequestDto productAuctionRequestDto) {
         SuccessResponseDto<Long> response = restClient.post()
                 .uri("/{productId}/{publicId}", productId, publicId)
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(productAuctionRequestDto)
                 .retrieve()
-                .onStatus(HttpStatusCode::isError, (httpRequest, httpResponse) -> {
-                    throw new CustomException(ErrorType.AUCTION_CREATE_FAILED);
-                })
+                .onStatus(HttpStatusCode::isError,
+                    (req, res) -> errorHandler.handleWithDefault(req, res, ErrorType.AUCTION_CREATE_FAILED))
                 .body(new ParameterizedTypeReference<>() {
                 });
 
-        Long result = (response != null) ? response.data() : null;
-
-        //result값이 null 인경우 경매정보 생성 실패 인식
-        return Optional.ofNullable(result)
+        return Optional.ofNullable(response)
+                .map(SuccessResponseDto::data)
                 .orElseThrow(() -> new CustomException(ErrorType.AUCTION_CREATE_FAILED));
     }
 
     public Long updateAuction(String publicId, ProductAuctionUpdateDto productAuctionUpdateDto) {
         SuccessResponseDto<Long> response = restClient.patch()
             .uri("/{publicId}", publicId)
+            .contentType(MediaType.APPLICATION_JSON)
             .body(productAuctionUpdateDto)
             .retrieve()
-            .onStatus(HttpStatusCode::isError, (httpRequest, httpResponse) -> {
-                throw new CustomException(ErrorType.AUCTION_UPDATE_FAILED);
-            })
-            .body(new ParameterizedTypeReference<>() {});
+            .onStatus(HttpStatusCode::isError, (httpRequest, httpResponse)
+                -> errorHandler.handleWithDefault(httpRequest, httpResponse, ErrorType.AUCTION_UPDATE_FAILED))
+            .body(new ParameterizedTypeReference<>() {
+            });
 
-        Long result = (response != null) ? response.data() : null;
-
-        return Optional.ofNullable(result)
+        return Optional.ofNullable(response)
+            .map(SuccessResponseDto::data)
             .orElseThrow(() -> new CustomException(ErrorType.AUCTION_UPDATE_FAILED));
     }
 
@@ -62,9 +64,8 @@ public class AuctionApiClient {
         restClient.delete()
             .uri("/{productId}/{publicId}", productId ,publicId)
             .retrieve()
-            .onStatus(HttpStatusCode::isError, (httpRequest, httpResponse) -> {
-                throw new CustomException(ErrorType.AUCTION_DELETE_FAILED);
-            })
+            .onStatus(HttpStatusCode::isError,
+                (httpRequest, httpResponse) -> errorHandler.handleWithDefault(httpRequest, httpResponse, ErrorType.AUCTION_DELETE_FAILED))
             .toBodilessEntity();
     }
 }

--- a/src/main/java/com/bugzero/rarego/shared/member/out/MemberApiClient.java
+++ b/src/main/java/com/bugzero/rarego/shared/member/out/MemberApiClient.java
@@ -50,7 +50,7 @@ public class MemberApiClient {
                     .header("X-Public-Id", publicId)
                     .retrieve()
                     .onStatus(HttpStatusCode::isError,
-                            (req, res) -> errorHandler.handleWithDefault(req, res, ErrorType.MEMBER_NOT_FOUND))
+                            (httpRequest, httpResponse) -> errorHandler.handleWithDefault(httpRequest, httpResponse, ErrorType.MEMBER_NOT_FOUND))
                     .body(new ParameterizedTypeReference<>() {
                     });
 

--- a/src/main/java/com/bugzero/rarego/shared/member/out/MemberApiClient.java
+++ b/src/main/java/com/bugzero/rarego/shared/member/out/MemberApiClient.java
@@ -1,20 +1,28 @@
 package com.bugzero.rarego.shared.member.out;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
 import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.exception.InternalApiErrorHandler;
 import com.bugzero.rarego.global.response.ErrorType;
 import com.bugzero.rarego.global.response.SuccessResponseDto;
 import com.bugzero.rarego.shared.member.domain.MemberJoinRequestDto;
 import com.bugzero.rarego.shared.member.domain.MemberJoinResponseDto;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
 
 @Service
 public class MemberApiClient {
     private final RestClient restClient;
+    private final InternalApiErrorHandler errorHandler;
 
-    public MemberApiClient(@Value("${custom.global.internalBackUrl}") String internalBackUrl) {
+    public MemberApiClient(
+            @Value("${custom.global.internalBackUrl}") String internalBackUrl,
+            InternalApiErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
         this.restClient = RestClient.builder()
                 .baseUrl(internalBackUrl + "/api/v1/members")
                 .build();
@@ -24,8 +32,10 @@ public class MemberApiClient {
         MemberJoinRequestDto request = new MemberJoinRequestDto(email);
         SuccessResponseDto<MemberJoinResponseDto> response = restClient.post()
                 .uri("/me")
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(request)
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, errorHandler::handle)
                 .body(new ParameterizedTypeReference<>() {
                 });
         if (response == null || response.data() == null) {
@@ -35,11 +45,12 @@ public class MemberApiClient {
     }
 
     public Long findMemberIdByPublicId(String publicId) {
-        try {
             SuccessResponseDto<Long> response = restClient.get()
                     .uri("/me")
                     .header("X-Public-Id", publicId)
                     .retrieve()
+                    .onStatus(HttpStatusCode::isError,
+                            (req, res) -> errorHandler.handleWithDefault(req, res, ErrorType.MEMBER_NOT_FOUND))
                     .body(new ParameterizedTypeReference<>() {
                     });
 
@@ -48,8 +59,5 @@ public class MemberApiClient {
             }
 
             return response.data();
-        } catch (Exception e) {
-            throw new CustomException(ErrorType.MEMBER_NOT_FOUND);
-        }
     }
 }

--- a/src/main/java/com/bugzero/rarego/shared/payment/out/PaymentApiClient.java
+++ b/src/main/java/com/bugzero/rarego/shared/payment/out/PaymentApiClient.java
@@ -2,10 +2,13 @@ package com.bugzero.rarego.shared.payment.out;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
 import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.exception.InternalApiErrorHandler;
 import com.bugzero.rarego.global.response.ErrorType;
 import com.bugzero.rarego.global.response.SuccessResponseDto;
 import com.bugzero.rarego.shared.payment.dto.DepositHoldRequestDto;
@@ -14,8 +17,12 @@ import com.bugzero.rarego.shared.payment.dto.DepositHoldResponseDto;
 @Service
 public class PaymentApiClient {
     private final RestClient restClient;
+    private final InternalApiErrorHandler errorHandler;
 
-    public PaymentApiClient(@Value("${custom.global.internalBackUrl}") String internalBackUrl) {
+    public PaymentApiClient(
+            @Value("${custom.global.internalBackUrl}") String internalBackUrl,
+            InternalApiErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
         this.restClient = RestClient.builder()
                 .baseUrl(internalBackUrl + "/api/v1/internal/payments")
                 .build();
@@ -25,8 +32,10 @@ public class PaymentApiClient {
         DepositHoldRequestDto request = new DepositHoldRequestDto(amount, memberPublicId, auctionId);
         SuccessResponseDto<DepositHoldResponseDto> response = restClient.post()
                 .uri("/deposits/hold")
+                .contentType(MediaType.APPLICATION_JSON)
                 .body(request)
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, errorHandler::handle)
                 .body(new ParameterizedTypeReference<>() {
                 });
         if (response == null || response.data() == null) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #183 

## 🚀 작업 내용
- [x] `InternalApiErrorHandler` 공통 에러 핸들러 컴포넌트 생성
- [x] `PaymentApiClient` 에러 핸들러 적용
- [x] `AuctionApiClient` 에러 핸들러 적용
- [x] `MemberApiClient` 에러 핸들러 적용
- [x] `ErrorType.findByCode()` 메서드 추가

## 🔍 리뷰 요청 사항 및 공유자료
에러 핸들러가 필요한 부분에 모두 적용했습니다. 
추후에 internal api 구현시 유사하게 핸들러 적용해주시면 됩니다!

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분