### PR TITLE
[FIX/member] 내부 API InternalMemberController로 이동

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/member/in/InternalMemberController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/member/in/InternalMemberController.java
@@ -8,11 +8,14 @@ import org.springframework.web.bind.annotation.RestController;
 import com.bugzero.rarego.boundedContext.member.app.MemberFacade;
 import com.bugzero.rarego.global.response.SuccessResponseDto;
 import com.bugzero.rarego.global.response.SuccessType;
+import com.bugzero.rarego.shared.member.domain.MemberJoinRequestDto;
+import com.bugzero.rarego.shared.member.domain.MemberJoinResponseDto;
 import com.bugzero.rarego.shared.member.domain.MemberWithdrawRequestDto;
 import com.bugzero.rarego.shared.member.domain.MemberWithdrawResponseDto;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +26,15 @@ import lombok.RequiredArgsConstructor;
 @Hidden
 public class InternalMemberController {
 	private final MemberFacade memberFacade;
+
+	@SecurityRequirement(name = "bearerAuth")
+	@Operation(summary = "소셜 로그인 이후 Member 생성(회원 가입)", description = "소셜 로그인 결과(email/provider)를 받아 회원가입 처리합니다.")
+	@PostMapping("/me")
+	public SuccessResponseDto<MemberJoinResponseDto> join(@RequestBody MemberJoinRequestDto requestDto) {
+		MemberJoinResponseDto responseDto = memberFacade.join(requestDto.email());
+		return SuccessResponseDto.from(SuccessType.CREATED, responseDto);
+	}
+
 
 	@Operation(summary = "회원 탈퇴", description = "내부 시스템에서 회원을 소프트 삭제합니다")
 	@PostMapping("/withdraw")

--- a/src/main/java/com/bugzero/rarego/boundedContext/member/in/MemberController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/member/in/MemberController.java
@@ -1,6 +1,7 @@
 package com.bugzero.rarego.boundedContext.member.in;
 
 import com.bugzero.rarego.boundedContext.auction.app.AuctionFacade;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,16 +32,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberController {
 
-  private final MemberFacade memberFacade;
-  private final AuctionFacade auctionFacade;
-
-	@SecurityRequirement(name = "bearerAuth")
-	@Operation(summary = "소셜 로그인 이후 Member 생성(회원 가입)", description = "소셜 로그인 결과(email/provider)를 받아 회원가입 처리합니다.")
-	@PostMapping("/me")
-	public SuccessResponseDto<MemberJoinResponseDto> join(@RequestBody MemberJoinRequestDto requestDto) {
-		MemberJoinResponseDto responseDto = memberFacade.join(requestDto.email());
-		return SuccessResponseDto.from(SuccessType.CREATED, responseDto);
-	}
+	private final MemberFacade memberFacade;
 
 	@SecurityRequirement(name = "bearerAuth")
 	@Operation(summary = "회원 본인 조회", description = "본인의 정보를 조회합니다.")

--- a/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
@@ -36,6 +36,7 @@ public enum ErrorType {
     MEMBER_IDENTITY_ALREADY_VERIFIED(409, 1021, "이미 본인인증이 완료되었습니다."),
     MEMBER_NICKNAME_ALREADY_EXISTS(409, 1022, "이미 존재하는 닉네임입니다."),
     MEMBER_MEMBER_DELETED(403, 1023, "탈퇴한 계정입니다."),
+    MEMBER_WITHDRAW_FAILED(500, 1024, "회원 탈퇴에 실패했습니다."),
 
     // Auth/JWT (1500 ~ 1999)
     AUTH_MEMBER_REQUIRED(400, 1501, "회원 정보가 필요합니다."),

--- a/src/main/java/com/bugzero/rarego/shared/member/out/MemberApiClient.java
+++ b/src/main/java/com/bugzero/rarego/shared/member/out/MemberApiClient.java
@@ -15,70 +15,48 @@ import com.bugzero.rarego.shared.member.domain.MemberJoinRequestDto;
 import com.bugzero.rarego.shared.member.domain.MemberJoinResponseDto;
 import com.bugzero.rarego.shared.member.domain.MemberWithdrawRequestDto;
 import com.bugzero.rarego.shared.member.domain.MemberWithdrawResponseDto;
-import org.springframework.beans.factory.annotation.Value;
 
 @Service
 public class MemberApiClient {
-    private final RestClient restClient;
-    private final RestClient internalRestClient;
-    private final InternalApiErrorHandler errorHandler;
+	private final RestClient internalRestClient;
+	private final InternalApiErrorHandler errorHandler;
 
-    public MemberApiClient(
-            @Value("${custom.global.internalBackUrl}") String internalBackUrl,
-            InternalApiErrorHandler errorHandler) {
-        this.errorHandler = errorHandler;
-        this.restClient = RestClient.builder()
-                .baseUrl(internalBackUrl + "/api/v1/members")
-                .build();
-        this.internalRestClient = RestClient.builder()
-                .baseUrl(internalBackUrl + "/api/v1/internal/members")
-                .build();
-    }
+	public MemberApiClient(
+		@Value("${custom.global.internalBackUrl}") String internalBackUrl,
+		InternalApiErrorHandler errorHandler) {
+		this.errorHandler = errorHandler;
+		this.internalRestClient = RestClient.builder()
+			.baseUrl(internalBackUrl + "/api/v1/internal/members")
+			.build();
+	}
 
-    public MemberJoinResponseDto join(String email) {
-        MemberJoinRequestDto request = new MemberJoinRequestDto(email);
-        SuccessResponseDto<MemberJoinResponseDto> response = restClient.post()
-                .uri("/me")
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(request)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, errorHandler::handle)
-                .body(new ParameterizedTypeReference<>() {
-                });
-        if (response == null || response.data() == null) {
-            throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
-        }
-        return response.data();
-    }
+	public MemberJoinResponseDto join(String email) {
+		MemberJoinRequestDto request = new MemberJoinRequestDto(email);
+		SuccessResponseDto<MemberJoinResponseDto> response = internalRestClient.post()
+			.uri("/me")
+			.contentType(MediaType.APPLICATION_JSON)
+			.body(request)
+			.retrieve()
+			.onStatus(HttpStatusCode::isError, errorHandler::handle)
+			.body(new ParameterizedTypeReference<>() {
+			});
+		if (response == null || response.data() == null) {
+			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+		}
+		return response.data();
+	}
 
-    public Long findMemberIdByPublicId(String publicId) {
-            SuccessResponseDto<Long> response = restClient.get()
-                    .uri("/me")
-                    .header("X-Public-Id", publicId)
-                    .retrieve()
-                    .onStatus(HttpStatusCode::isError,
-                            (httpRequest, httpResponse) -> errorHandler.handleWithDefault(httpRequest, httpResponse, ErrorType.MEMBER_NOT_FOUND))
-                    .body(new ParameterizedTypeReference<>() {
-                    });
-
-            if (response == null || response.data() == null) {
-                throw new CustomException(ErrorType.MEMBER_NOT_FOUND);
-            }
-
-            return response.data();
-    }
-
-    public String withdraw(String publicId) {
-        MemberWithdrawRequestDto request = new MemberWithdrawRequestDto(publicId);
-        SuccessResponseDto<MemberWithdrawResponseDto> response = internalRestClient.post()
-                .uri("/withdraw")
-                .body(request)
-                .retrieve()
-                .body(new ParameterizedTypeReference<>() {
-                });
-        if (response == null || response.data() == null) {
-            throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
-        }
-        return response.data().publicId();
-    }
+	public String withdraw(String publicId) {
+		MemberWithdrawRequestDto request = new MemberWithdrawRequestDto(publicId);
+		SuccessResponseDto<MemberWithdrawResponseDto> response = internalRestClient.post()
+			.uri("/withdraw")
+			.body(request)
+			.retrieve()
+			.body(new ParameterizedTypeReference<>() {
+			});
+		if (response == null || response.data() == null) {
+			throw new CustomException(ErrorType.INTERNAL_SERVER_ERROR);
+		}
+		return response.data().publicId();
+	}
 }

--- a/src/main/java/com/bugzero/rarego/shared/member/out/MemberApiClient.java
+++ b/src/main/java/com/bugzero/rarego/shared/member/out/MemberApiClient.java
@@ -37,7 +37,10 @@ public class MemberApiClient {
 			.contentType(MediaType.APPLICATION_JSON)
 			.body(request)
 			.retrieve()
-			.onStatus(HttpStatusCode::isError, errorHandler::handle)
+			.onStatus(HttpStatusCode::isError,
+				(httpRequest, httpResponse) -> errorHandler.handleWithDefault(httpRequest, httpResponse,
+					ErrorType.MEMBER_JOIN_FAILED))
+
 			.body(new ParameterizedTypeReference<>() {
 			});
 		if (response == null || response.data() == null) {
@@ -52,6 +55,9 @@ public class MemberApiClient {
 			.uri("/withdraw")
 			.body(request)
 			.retrieve()
+			.onStatus(HttpStatusCode::isError,
+				(httpRequest, httpResponse) -> errorHandler.handleWithDefault(httpRequest, httpResponse,
+					ErrorType.MEMBER_WITHDRAW_FAILED))
 			.body(new ParameterizedTypeReference<>() {
 			});
 		if (response == null || response.data() == null) {

--- a/src/test/java/com/bugzero/rarego/boundedContext/member/in/InternalMemberControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/member/in/InternalMemberControllerTest.java
@@ -20,6 +20,8 @@ import com.bugzero.rarego.global.aspect.ResponseAspect;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
 import com.bugzero.rarego.global.response.SuccessType;
+import com.bugzero.rarego.shared.member.domain.MemberJoinRequestDto;
+import com.bugzero.rarego.shared.member.domain.MemberJoinResponseDto;
 import com.bugzero.rarego.shared.member.domain.MemberWithdrawRequestDto;
 
 import tools.jackson.databind.ObjectMapper;
@@ -37,6 +39,39 @@ class InternalMemberControllerTest {
 
 	@MockitoBean
 	private MemberFacade memberFacade;
+
+	@Test
+	@DisplayName("성공: 회원 가입 요청이 정상 처리되면 HTTP 201과 결과 데이터를 반환한다")
+	void join_success() throws Exception {
+		MemberJoinRequestDto requestDto = new MemberJoinRequestDto("new@example.com");
+		MemberJoinResponseDto responseDto = new MemberJoinResponseDto("newbie", "public-id");
+
+		given(memberFacade.join("new@example.com")).willReturn(responseDto);
+
+		mockMvc.perform(post("/api/v1/internal/members/me")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.status").value(SuccessType.CREATED.getHttpStatus()))
+			.andExpect(jsonPath("$.message").value(SuccessType.CREATED.getMessage()))
+			.andExpect(jsonPath("$.data.memberPublicId").value("public-id"));
+	}
+
+	@Test
+	@DisplayName("실패: 이메일이 비어있으면 HTTP 400을 반환한다")
+	void join_fail_empty_email() throws Exception {
+		MemberJoinRequestDto requestDto = new MemberJoinRequestDto("");
+
+		given(memberFacade.join("")).willThrow(new CustomException(ErrorType.MEMBER_EMAIL_EMPTY));
+
+		mockMvc.perform(post("/api/v1/internal/members/me")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value(ErrorType.MEMBER_EMAIL_EMPTY.getHttpStatus()))
+			.andExpect(jsonPath("$.message").value(ErrorType.MEMBER_EMAIL_EMPTY.getMessage()));
+	}
+
 
 	@Test
 	@DisplayName("성공: 회원 탈퇴 요청이 정상 처리되면 HTTP 200과 결과 데이터를 반환한다")

--- a/src/test/java/com/bugzero/rarego/boundedContext/member/in/MemberControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/member/in/MemberControllerTest.java
@@ -58,38 +58,6 @@ class MemberControllerTest {
 	private MemberFacade memberFacade;
 
 	@Test
-	@DisplayName("성공: 회원 가입 요청이 정상 처리되면 HTTP 201과 결과 데이터를 반환한다")
-	void join_success() throws Exception {
-		MemberJoinRequestDto requestDto = new MemberJoinRequestDto("new@example.com");
-		MemberJoinResponseDto responseDto = new MemberJoinResponseDto("newbie", "public-id");
-
-		given(memberFacade.join("new@example.com")).willReturn(responseDto);
-
-		mockMvc.perform(post("/api/v1/members/me")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(requestDto)))
-			.andExpect(status().isCreated())
-			.andExpect(jsonPath("$.status").value(SuccessType.CREATED.getHttpStatus()))
-			.andExpect(jsonPath("$.message").value(SuccessType.CREATED.getMessage()))
-			.andExpect(jsonPath("$.data.memberPublicId").value("public-id"));
-	}
-
-	@Test
-	@DisplayName("실패: 이메일이 비어있으면 HTTP 400을 반환한다")
-	void join_fail_empty_email() throws Exception {
-		MemberJoinRequestDto requestDto = new MemberJoinRequestDto("");
-
-		given(memberFacade.join("")).willThrow(new CustomException(ErrorType.MEMBER_EMAIL_EMPTY));
-
-		mockMvc.perform(post("/api/v1/members/me")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(requestDto)))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.status").value(ErrorType.MEMBER_EMAIL_EMPTY.getHttpStatus()))
-			.andExpect(jsonPath("$.message").value(ErrorType.MEMBER_EMAIL_EMPTY.getMessage()));
-	}
-
-	@Test
 	@DisplayName("성공: 내 정보 조회 요청이 정상 처리되면 회원 정보를 반환한다")
 	void getMe_success() throws Exception {
 		MemberMeResponseDto responseDto = new MemberMeResponseDto(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #186 

## 🚀 작업 내용
- [x] MemberController.join -> InternalMemberController.join
- [x] MemberApiClient.findMemberByPublicId 삭제

## 🔍 리뷰 요청 사항 및 공유자료
- 테스트코드, 회원가입 및 로그인이 잘 동작하는지 확인 부탁드립니다.

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
2+
