### PR TITLE
[FIX/product] 경매일정을 확정하는 api를 요청할 때 받는 인자를 auctionId -> productId로 변경

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/out/AuctionRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/out/AuctionRepository.java
@@ -1,8 +1,10 @@
 package com.bugzero.rarego.boundedContext.auction.out;
 
-import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
-import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,10 +13,10 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import com.bugzero.rarego.boundedContext.auction.domain.Auction;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
+
+import jakarta.persistence.LockModeType;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpecificationExecutor<Auction> {
     // 비관적 락 처리
@@ -38,6 +40,9 @@ public interface AuctionRepository extends JpaRepository<Auction, Long>, JpaSpec
 
     //삭제가 되지 않은 경매 정보만 반환
     Optional<Auction> findByIdAndDeletedIsFalse(Long auctionId);
+
+    //경매일정이 확정되지 않은 경매 정보만 반환
+    Optional<Auction> findByProductIdAndStartTimeIsNull(Long productId);
 
     // 필터링 없는 조건
     Page<Auction> findAllByProductIdIn(Collection<Long> productIds, Pageable pageable);

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/auction/app/AuctionDetermineStartAuctionUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/auction/app/AuctionDetermineStartAuctionUseCase.java
@@ -19,16 +19,11 @@ public class AuctionDetermineStartAuctionUseCase {
 	private final AuctionRepository auctionRepository;
 
 	@Transactional
-	public Long determineStartAuction(Long AuctionId) {
+	public Long determineStartAuction(Long productId) {
 
-		//햔제 삭제되지 않은 경매만 가져올 수 있도록 함.
-		Auction auction = auctionRepository.findByIdAndDeletedIsFalse(AuctionId)
+		//현재 경매일정이 정해지지 않은 경매만 가져올 수 있도록 함.
+		Auction auction = auctionRepository.findByProductIdAndStartTimeIsNull(productId)
 			.orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
-
-		//이미 시작시간이 정해진 경매라면 예외처리
-		if (auction.hasStartTime()) {
-			throw new CustomException(ErrorType.AUCTION_ALREADY_HAS_START_TIME);
-		}
 
 		auction.determineStart(determineStartTime());
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/product/auction/in/AuctionStartAuctionController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/auction/in/AuctionStartAuctionController.java
@@ -26,11 +26,11 @@ public class AuctionStartAuctionController {
 	@SecurityRequirement(name = "bearerAuth")
 	@Operation(summary = "검수승인 후 경매일정 확정", description = "관리자가 검수 승인 후 해당상품의 경매일정을 확정합니다.")
 	@PreAuthorize("hasRole('ADMIN')")
-	@PatchMapping("/{auctionId}/startTime")
+	@PatchMapping("/{productId}/startTime")
 	public SuccessResponseDto<Long> deterMineStartAuction(
-		@PathVariable Long auctionId
+		@PathVariable Long productId
 	) {
 		return SuccessResponseDto.from(SuccessType.OK,
-			auctionDetermineStartAuctionUseCase.determineStartAuction(auctionId));
+			auctionDetermineStartAuctionUseCase.determineStartAuction(productId));
 	}
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/product/auction/in/AuctionStartAuctionControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/product/auction/in/AuctionStartAuctionControllerTest.java
@@ -40,17 +40,17 @@ class AuctionStartAuctionControllerTest {
 	@DisplayName("성공 - 시작 시간 확정 요청 시 200 OK와 경매 ID를 반환한다")
 	void createAuction_Success() throws Exception {
 		// given
-		Long auctionId = 1L;
+		Long productId = 1L;
 
-		given(auctionDetermineStartAuctionUseCase.determineStartAuction(eq(auctionId)))
-			.willReturn(auctionId);
+		given(auctionDetermineStartAuctionUseCase.determineStartAuction(eq(productId)))
+			.willReturn(productId);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/auctions/{auctionId}/startTime", auctionId) // 1. patch 사용 및 경로 수정
+		mockMvc.perform(patch("/api/v1/auctions/{auctionId}/startTime", productId) // 1. patch 사용 및 경로 수정
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk()) // 2. isCreated() 대신 isOk() 사용
 			.andExpect(jsonPath("$.status").value(200)) // SuccessResponseDto 구조 검증
-			.andExpect(jsonPath("$.data").value(auctionId))
+			.andExpect(jsonPath("$.data").value(productId))
 			.andDo(print());
 	}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #189

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->
- 관리자가 검수를 하기위해 상품 목록 조회시 반환값에 auctionId가 포함되지 않음. 이에 따라  검수 승인 시에 경매일정을 확정시키는 api 요청이 들어가야 하는데 기존 api 는 auctionId를 받아 해당 경매 정보를 수정하는 로직이었기 때문에 반환 값만으로 해당 요청을 처리할 수 없었음.
- 그렇다고 상품 도메인에서 경매 Id를 반환하는 것은 결합도가 높아질 수 있음. (현재 product엔티티에는 따로 경매 정보가 들어가 있지 않음. auction -> product 단방향 관계) 
- 대신 Auction 에 ProductId 가 포함되어 있기 때문에 ProductId를 활용하여 일정이 확정되지 않은 경매정보를 찾아 경매일정을 확정시키는 로직으로 변경

- [ ] 검수 승인 시 경매일정을 확정시키는 api 요청 시 인자를 productId로 받는 것으로 변경

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->

## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션을 지켰습니다.
- [X] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
3분
