### PR TITLE
[FIX/auction] 나의 판매 목록 조회 버그 수정

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/product/out/ProductRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/out/ProductRepository.java
@@ -19,7 +19,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	Optional<Product> findByIdAndDeletedIsFalse(Long id);
 
 	// 판매자의 모든 상품(경매) ID 조회
-	@Query("SELECT p.id FROM Product p WHERE p.seller = :sellerId")
+	@Query("SELECT p.id FROM Product p WHERE p.seller.id = :sellerId")
 	List<Long> findAllIdsBySellerId(@Param("sellerId") Long sellerId);
 
 	// 상품 ID 목록으로 상품 엔티티 일괄 조회
@@ -28,31 +28,31 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	// 동적 쿼리 또는 COALESCE를 사용한 검색 조건 구현
 	// keyword가 null/빈문자열이면 무시, category가 null이면 무시
 	@Query("""
-        SELECT p.id FROM Product p
-        WHERE (:keyword IS NULL OR :keyword = '' OR p.name LIKE %:keyword%)
-        AND (:category IS NULL OR :category = '' OR p.category = :category)
-    """)
+		    SELECT p.id FROM Product p
+		    WHERE (:keyword IS NULL OR :keyword = '' OR p.name LIKE %:keyword%)
+		    AND (:category IS NULL OR :category = '' OR p.category = :category)
+		""")
 	List<Long> findIdsBySearchCondition(
 		@Param("keyword") String keyword,
 		@Param("category") String category
 	);
 
 	@Query("""
-       SELECT new com.bugzero.rarego.shared.product.dto.ProductResponseForInspectionDto(
-           p.id, 
-           p.name, 
-           s.email, 
-           p.category, 
-           p.inspectionStatus, 
-           img.imageUrl
-       )
-       FROM Product p
-       JOIN p.seller s
-       LEFT JOIN p.images img ON img.product = p AND img.sortOrder = 0
-       WHERE (:name IS NULL OR p.name LIKE %:name%)
-         AND (:category IS NULL OR p.category = :category)
-         AND (:status IS NULL OR p.inspectionStatus = :status)
-       """)
+		SELECT new com.bugzero.rarego.shared.product.dto.ProductResponseForInspectionDto(
+		    p.id, 
+		    p.name, 
+		    s.email, 
+		    p.category, 
+		    p.inspectionStatus, 
+		    img.imageUrl
+		)
+		FROM Product p
+		JOIN p.seller s
+		LEFT JOIN p.images img ON img.product = p AND img.sortOrder = 0
+		WHERE (:name IS NULL OR p.name LIKE %:name%)
+		  AND (:category IS NULL OR p.category = :category)
+		  AND (:status IS NULL OR p.inspectionStatus = :status)
+		""")
 	Page<ProductResponseForInspectionDto> readProductsForAdmin(
 		@Param("name") String name,
 		@Param("category") Category category,


### PR DESCRIPTION
# 🐛 버그 수정 PR인 경우(해당 시 작성)

## #️⃣ 연관된 이슈
close: #193 

## 📝 수정 요약
<!-- 먼저 버그에 대한 간단한 설명을 적어주세요 -->

- 🚨 문제점
  - 나의 판매 상품(경매) 목록 조회 에러
- 🔍 원인 분석
  - ProductRepository의 findAllIdsBySellerId()의 인자로 sellerId를 받는데 쿼리는 seller 객체를 요구
- 💡 해결 방법
  - 쿼리에서 id를 받도록 수정

<img width="829" height="365" alt="image" src="https://github.com/user-attachments/assets/2e97a1fc-8d10-4005-9251-2783c643b63f" />

## 🛠️ PR 유형
- [x] 버그 수정
- [ ] 테스트 리팩토링
- [ ] 코드 리팩토링
- [ ] 문서 수정

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
1분