### PR TITLE
[FIX/auction] 경매 상세 조회 정보 보강 및 미정 경매 조회 안정화

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionBookmarkUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionBookmarkUseCase.java
@@ -44,20 +44,15 @@ public class AuctionBookmarkUseCase {
     }
 
     @Transactional
-    public WishlistRemoveResponseDto removeBookmark(String publicId, Long bookmarkId) {
+    public WishlistRemoveResponseDto removeBookmark(String publicId, Long auctionId) {
         AuctionMember member = auctionMemberRepository.findByPublicId(publicId)
                 .orElseThrow(() -> new CustomException(ErrorType.MEMBER_NOT_FOUND));
 
-        AuctionBookmark bookmark = auctionBookmarkRepository.findById(bookmarkId)
+        AuctionBookmark bookmark = auctionBookmarkRepository.findByAuctionIdAndMemberId(auctionId, member.getId())
                 .orElseThrow(() -> new CustomException(ErrorType.BOOKMARK_NOT_FOUND));
-
-        // 해당 북마크의 주인이 현재 요청한 사용자가 맞는지 체크
-        if (!bookmark.getMemberId().equals(member.getId())) {
-            throw new CustomException(ErrorType.BOOKMARK_UNAUTHORIZED_ACCESS);
-        }
 
         auctionBookmarkRepository.delete(bookmark);
 
-        return WishlistRemoveResponseDto.of(true, bookmarkId);
+        return WishlistRemoveResponseDto.of(true, auctionId);
     }
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacade.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionFacade.java
@@ -1,6 +1,5 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -109,8 +108,8 @@ public class AuctionFacade {
 
     // 관심 경매 해제
     @Transactional
-    public WishlistRemoveResponseDto removeBookmark(String publicId, Long bookmarkId) {
-        return auctionBookmarkUseCase.removeBookmark(publicId, bookmarkId);
+    public WishlistRemoveResponseDto removeBookmark(String publicId, Long auctionId) {
+        return auctionBookmarkUseCase.removeBookmark(publicId, auctionId);
     }
 
     // 내 관심 경매 목록 조회

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionReadUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionReadUseCase.java
@@ -158,13 +158,13 @@ public class AuctionReadUseCase {
 		Product product = productRepository.findById(auction.getProductId())
 				.orElseThrow(() -> new CustomException(ErrorType.PRODUCT_NOT_FOUND));
 
-		// 1-3. 썸네일 이미지 조회
+		// 1-3. 이미지 목록 조회 (전체)
 		List<ProductImage> productImages = productImageRepository.findAllByProductId(product.getId());
-		String thumbnail = productImages.stream()
-				.min(Comparator.comparingInt(ProductImage::getSortOrder))
+		List<String> imageUrls = productImages.stream()
+				.sorted(Comparator.comparingInt(ProductImage::getSortOrder))
 				.map(ProductImage::getImageUrl)
 				.map(s3PresignerUrlUseCase::getPresignedGetUrl)
-				.orElse(null);
+				.toList();
 
 		// 2. 전체 최고가 입찰 조회
 		Bid highestBid = bidRepository.findTopByAuctionIdOrderByBidAmountDesc(auctionId)
@@ -184,7 +184,7 @@ public class AuctionReadUseCase {
 				auction,
 				product.getName(),
 				product.getDescription(),
-				thumbnail,
+				imageUrls,
 				highestBid,
 				myLastBid,
 				memberId);

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/in/AuctionController.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/in/AuctionController.java
@@ -95,12 +95,12 @@ public class AuctionController {
 
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "관심 경매 해제", description = "특정 경매를 관심 목록에서 제거합니다")
-    @DeleteMapping("/{bookmarkId}/bookmarks")
+    @DeleteMapping("/{auctionId}/bookmarks")
     public SuccessResponseDto<WishlistRemoveResponseDto> removeBookmark(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
-            @PathVariable Long bookmarkId
+            @PathVariable Long auctionId
     ) {
-        WishlistRemoveResponseDto response = auctionFacade.removeBookmark(memberPrincipal.publicId(), bookmarkId);
+        WishlistRemoveResponseDto response = auctionFacade.removeBookmark(memberPrincipal.publicId(), auctionId);
         return SuccessResponseDto.from(SuccessType.OK, response);
     }
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/in/dto/WishlistRemoveResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/in/dto/WishlistRemoveResponseDto.java
@@ -2,9 +2,8 @@ package com.bugzero.rarego.boundedContext.auction.in.dto;
 
 public record WishlistRemoveResponseDto(
         boolean removed,
-        Long bookmarkId
-) {
-    public static WishlistRemoveResponseDto of(boolean removed, Long bookmarkId) {
-        return new WishlistRemoveResponseDto(removed, bookmarkId);
+        Long auctionId) {
+    public static WishlistRemoveResponseDto of(boolean removed, Long auctionId) {
+        return new WishlistRemoveResponseDto(removed, auctionId);
     }
 }

--- a/src/main/java/com/bugzero/rarego/shared/auction/dto/AuctionDetailResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/shared/auction/dto/AuctionDetailResponseDto.java
@@ -9,6 +9,9 @@ import java.time.LocalDateTime;
 public record AuctionDetailResponseDto(
 	Long auctionId,
 	Long productId,
+	String productName,
+	String productDescription,
+	String imageUrl,
 	AuctionStatus status,
 	LocalDateTime startTime,
 	LocalDateTime endTime,
@@ -37,6 +40,9 @@ public record AuctionDetailResponseDto(
 
 	public static AuctionDetailResponseDto from(
 		Auction auction,
+		String productName,
+		String productDescription,
+		String imageUrl,
 		Bid highestBid,
 		Bid myLastBid,
 		Long currentMemberId
@@ -44,7 +50,7 @@ public record AuctionDetailResponseDto(
 		LocalDateTime now = LocalDateTime.now();
 
 		long remainingSeconds = 0;
-		if (auction.getEndTime().isAfter(now)) {
+		if (auction.getEndTime() != null && auction.getEndTime().isAfter(now)) {
 			remainingSeconds = Duration.between(now, auction.getEndTime()).getSeconds();
 		}
 
@@ -76,12 +82,13 @@ public record AuctionDetailResponseDto(
 		boolean isSeller = (currentMemberId != null) && auction.getSellerId().equals(currentMemberId);
 
 		boolean canBid = auction.getStatus() == AuctionStatus.IN_PROGRESS
+			&& auction.getEndTime() != null
 			&& auction.getEndTime().isAfter(now)
 			&& !isGuest
 			&& !isSeller
 			&& !isMyHighestBid;
 
-		int minBidPrice = auction.getCurrentPrice() + auction.getTickSize();
+		int minBidPrice = currentPrice + auction.getTickSize();
 		Long highestBidderId = (highestBid != null) ? highestBid.getBidderId() : null;
 
 		BidInfo bidInfo = new BidInfo(
@@ -99,6 +106,9 @@ public record AuctionDetailResponseDto(
 		return new AuctionDetailResponseDto(
 			auction.getId(),
 			auction.getProductId(),
+			productName,
+			productDescription,
+			imageUrl,
 			auction.getStatus(),
 			auction.getStartTime(),
 			auction.getEndTime(),

--- a/src/main/java/com/bugzero/rarego/shared/auction/dto/AuctionDetailResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/shared/auction/dto/AuctionDetailResponseDto.java
@@ -5,13 +5,14 @@ import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
 import com.bugzero.rarego.boundedContext.auction.domain.Bid;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record AuctionDetailResponseDto(
 	Long auctionId,
 	Long productId,
 	String productName,
 	String productDescription,
-	String imageUrl,
+	List<String> imageUrls,
 	AuctionStatus status,
 	LocalDateTime startTime,
 	LocalDateTime endTime,
@@ -30,7 +31,8 @@ public record AuctionDetailResponseDto(
 		boolean canBid,
 		int minBidPrice,
 		Long highestBidderId,
-		boolean isMyHighestBid
+		boolean isMyHighestBid,
+		boolean isSeller
 	) {}
 
 	public record MyParticipationInfo(
@@ -42,7 +44,7 @@ public record AuctionDetailResponseDto(
 		Auction auction,
 		String productName,
 		String productDescription,
-		String imageUrl,
+		List<String> imageUrls,
 		Bid highestBid,
 		Bid myLastBid,
 		Long currentMemberId
@@ -88,15 +90,16 @@ public record AuctionDetailResponseDto(
 			&& !isSeller
 			&& !isMyHighestBid;
 
-		int minBidPrice = currentPrice + auction.getTickSize();
+		// 첫 입찰인 경우(highestBid == null) 시작가(currentPrice)로 입찰 가능
+		int minBidPrice = (highestBid == null) ? currentPrice : currentPrice + auction.getTickSize();
 		Long highestBidderId = (highestBid != null) ? highestBid.getBidderId() : null;
 
 		BidInfo bidInfo = new BidInfo(
 			canBid,
 			minBidPrice,
 			highestBidderId,
-			isMyHighestBid
-		);
+			isMyHighestBid,
+			isSeller);
 
 		MyParticipationInfo myParticipationInfo = new MyParticipationInfo(
 			hasBid,
@@ -108,7 +111,7 @@ public record AuctionDetailResponseDto(
 			auction.getProductId(),
 			productName,
 			productDescription,
-			imageUrl,
+			imageUrls,
 			auction.getStatus(),
 			auction.getStartTime(),
 			auction.getEndTime(),

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionBookmarkUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionBookmarkUseCaseTest.java
@@ -41,20 +41,20 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class AuctionBookmarkUseCaseTest {
 
-    @Mock
-    private AuctionBookmarkRepository auctionBookmarkRepository;
+        @Mock
+        private AuctionBookmarkRepository auctionBookmarkRepository;
 
-    @Mock
-    private AuctionSupport auctionSupport;
+        @Mock
+        private AuctionSupport auctionSupport;
 
-    @InjectMocks
-    private AuctionBookmarkUseCase auctionBookmarkUseCase;
+        @InjectMocks
+        private AuctionBookmarkUseCase auctionBookmarkUseCase;
 
-    @Mock
-    private AuctionMemberRepository auctionMemberRepository;
+        @Mock
+        private AuctionMemberRepository auctionMemberRepository;
 
-    @Mock
-    private AuctionRepository auctionRepository;
+        @Mock
+        private AuctionRepository auctionRepository;
 
     @Test
     @DisplayName("관심 경매 등록 - 성공")
@@ -63,158 +63,125 @@ class AuctionBookmarkUseCaseTest {
         Long memberId = 100L;
         Long auctionId = 1L;
 
-        Auction auction = Auction.builder()
-                .productId(50L)
-                .startPrice(1000)
-                .startTime(LocalDateTime.now())
-                .endTime(LocalDateTime.now().plusDays(1))
-                .durationDays(1)
-                .sellerId(1L)
-                .build();
-        ReflectionTestUtils.setField(auction, "id", auctionId);
+                Auction auction = Auction.builder()
+                                .productId(50L)
+                                .startPrice(1000)
+                                .startTime(LocalDateTime.now())
+                                .endTime(LocalDateTime.now().plusDays(1))
+                                .durationDays(1)
+                                .sellerId(1L)
+                                .build();
+                ReflectionTestUtils.setField(auction, "id", auctionId);
 
-        given(auctionSupport.findAuctionById(auctionId))
-                .willReturn(auction);
+                given(auctionSupport.findAuctionById(auctionId))
+                                .willReturn(auction);
 
-        given(auctionBookmarkRepository.existsByAuctionIdAndMemberId(auctionId, memberId))
-                .willReturn(false);
+                given(auctionBookmarkRepository.existsByAuctionIdAndMemberId(auctionId, memberId))
+                                .willReturn(false);
 
-        // when
-        WishlistAddResponseDto result = auctionBookmarkUseCase.addBookmark(memberId, auctionId);
+                // when
+                WishlistAddResponseDto result = auctionBookmarkUseCase.addBookmark(memberId, auctionId);
 
-        // then
-        assertThat(result.bookmarked()).isTrue();
-        assertThat(result.auctionId()).isEqualTo(auctionId);
+                // then
+                assertThat(result.bookmarked()).isTrue();
+                assertThat(result.auctionId()).isEqualTo(auctionId);
 
-        verify(auctionBookmarkRepository).save(argThat(bookmark ->
-                bookmark.getMemberId().equals(memberId) &&
-                        bookmark.getAuctionId().equals(auctionId) &&
-                        bookmark.getProductId().equals(50L)
-        ));
-    }
+                verify(auctionBookmarkRepository).save(argThat(bookmark -> bookmark.getMemberId().equals(memberId) &&
+                                bookmark.getAuctionId().equals(auctionId) &&
+                                bookmark.getProductId().equals(50L)));
+        }
 
-    @Test
-    @DisplayName("관심 경매 등록 - 이미 북마크된 경우 예외 발생")
-    void addBookmark_AlreadyBookmarked() {
-        // given
-        Long memberId = 100L;
-        Long auctionId = 1L;
+        @Test
+        @DisplayName("관심 경매 등록 - 이미 북마크된 경우 예외 발생")
+        void addBookmark_AlreadyBookmarked() {
+                // given
+                Long memberId = 100L;
+                Long auctionId = 1L;
 
-        Auction auction = Auction.builder()
-                .productId(50L)
-                .startPrice(1000)
-                .startTime(LocalDateTime.now())
-                .endTime(LocalDateTime.now().plusDays(1))
-                .durationDays(1)
-                .sellerId(1L)
-                .build();
-        ReflectionTestUtils.setField(auction, "id", auctionId);
+                Auction auction = Auction.builder()
+                                .productId(50L)
+                                .startPrice(1000)
+                                .startTime(LocalDateTime.now())
+                                .endTime(LocalDateTime.now().plusDays(1))
+                                .durationDays(1)
+                                .sellerId(1L)
+                                .build();
+                ReflectionTestUtils.setField(auction, "id", auctionId);
 
-        given(auctionSupport.findAuctionById(auctionId))
-                .willReturn(auction);
+                given(auctionSupport.findAuctionById(auctionId))
+                                .willReturn(auction);
 
-        given(auctionBookmarkRepository.existsByAuctionIdAndMemberId(auctionId, memberId))
-                .willReturn(true);
+                given(auctionBookmarkRepository.existsByAuctionIdAndMemberId(auctionId, memberId))
+                                .willReturn(true);
 
-        // when & then
-        assertThatThrownBy(() -> auctionBookmarkUseCase.addBookmark(memberId, auctionId))
-                .isInstanceOf(CustomException.class)
-                .satisfies(ex -> assertThat(((CustomException) ex).getErrorType())
-                        .isEqualTo(ErrorType.BOOKMARK_ALREADY_EXISTS));
+                // when & then
+                assertThatThrownBy(() -> auctionBookmarkUseCase.addBookmark(memberId, auctionId))
+                                .isInstanceOf(CustomException.class)
+                                .satisfies(ex -> assertThat(((CustomException) ex).getErrorType())
+                                                .isEqualTo(ErrorType.BOOKMARK_ALREADY_EXISTS));
 
-        verify(auctionBookmarkRepository, never()).save(any(AuctionBookmark.class));
-    }
+                verify(auctionBookmarkRepository, never()).save(any(AuctionBookmark.class));
+        }
 
-    @Test
-    @DisplayName("관심 경매 해제 - 성공")
-    void removeBookmark_Success() {
-        // given
-        String publicId = "test-public-id";
-        Long memberId = 100L;
-        Long bookmarkId = 1L;
+        @Test
+        @DisplayName("관심 경매 해제 - 성공")
+        void removeBookmark_Success() {
+                // given
+                String publicId = "test-public-id";
+                Long memberId = 100L;
+                Long auctionId = 500L;
 
-        AuctionMember member = AuctionMember.builder().publicId(publicId).build();
-        ReflectionTestUtils.setField(member, "id", memberId);
+                AuctionMember member = AuctionMember.builder().publicId(publicId).build();
+                ReflectionTestUtils.setField(member, "id", memberId);
 
-        AuctionBookmark bookmark = AuctionBookmark.builder()
-                .memberId(memberId)
-                .auctionId(500L)
-                .productId(50L)
-                .build();
-        ReflectionTestUtils.setField(bookmark, "id", bookmarkId);
+                AuctionBookmark bookmark = AuctionBookmark.builder()
+                                .memberId(memberId)
+                                .auctionId(500L)
+                                .productId(50L)
+                                .build();
+                ReflectionTestUtils.setField(bookmark, "id", 1L);
 
-        given(auctionMemberRepository.findByPublicId(publicId))
-                .willReturn(Optional.of(member));
+                given(auctionMemberRepository.findByPublicId(publicId))
+                                .willReturn(Optional.of(member));
 
-        given(auctionBookmarkRepository.findById(bookmarkId))
-                .willReturn(Optional.of(bookmark));
+                given(auctionBookmarkRepository.findByAuctionIdAndMemberId(auctionId, memberId))
+                                .willReturn(Optional.of(bookmark));
 
-        // when
-        WishlistRemoveResponseDto result = auctionBookmarkUseCase.removeBookmark(publicId, bookmarkId);
+                // when
+                WishlistRemoveResponseDto result = auctionBookmarkUseCase.removeBookmark(publicId, auctionId);
 
-        // then
-        assertThat(result.removed()).isTrue();
-        assertThat(result.bookmarkId()).isEqualTo(bookmarkId);
+                // then
+                assertThat(result.removed()).isTrue();
+                assertThat(result.auctionId()).isEqualTo(auctionId);
 
-        verify(auctionBookmarkRepository).delete(bookmark);
-    }
+                verify(auctionBookmarkRepository).delete(bookmark);
+        }
 
-    @Test
-    @DisplayName("관심 경매 해제 - 북마크를 찾을 수 없는 경우 예외 발생")
-    void removeBookmark_BookmarkNotFound() {
-        // given
-        String publicId = "test-public-id";
-        Long memberId = 100L;
-        Long bookmarkId = 1L;
+        @Test
+        @DisplayName("관심 경매 해제 - 북마크를 찾을 수 없는 경우 예외 발생")
+        void removeBookmark_BookmarkNotFound() {
+                // given
+                String publicId = "test-public-id";
+                Long memberId = 100L;
+                Long auctionId = 500L;
 
-        AuctionMember member = AuctionMember.builder().publicId(publicId).build();
-        ReflectionTestUtils.setField(member, "id", memberId);
+                AuctionMember member = AuctionMember.builder().publicId(publicId).build();
+                ReflectionTestUtils.setField(member, "id", memberId);
 
-        given(auctionMemberRepository.findByPublicId(publicId))
-                .willReturn(Optional.of(member));
+                given(auctionMemberRepository.findByPublicId(publicId))
+                                .willReturn(Optional.of(member));
 
-        // 존재하지 않는 북마크 ID 조회 시나리오
-        given(auctionBookmarkRepository.findById(bookmarkId))
-                .willReturn(Optional.empty());
+                // 존재하지 않는 북마크 ID 조회 시나리오
+                given(auctionBookmarkRepository.findByAuctionIdAndMemberId(auctionId, memberId))
+                                .willReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> auctionBookmarkUseCase.removeBookmark(publicId, bookmarkId))
-                .isInstanceOf(CustomException.class)
-                .satisfies(ex -> assertThat(((CustomException) ex).getErrorType())
-                        .isEqualTo(ErrorType.BOOKMARK_NOT_FOUND));
+                // when & then
+                assertThatThrownBy(() -> auctionBookmarkUseCase.removeBookmark(publicId, auctionId))
+                                .isInstanceOf(CustomException.class)
+                                .satisfies(ex -> assertThat(((CustomException) ex).getErrorType())
+                                                .isEqualTo(ErrorType.BOOKMARK_NOT_FOUND));
 
-        verify(auctionBookmarkRepository, never()).delete(any(AuctionBookmark.class));
-    }
+                verify(auctionBookmarkRepository, never()).delete(any(AuctionBookmark.class));
+        }
 
-    @Test
-    @DisplayName("관심 경매 해제 - 소유자가 아닌 경우 예외 발생")
-    void removeBookmark_UnauthorizedAccess() {
-        // given
-        String publicId = "test-public-id";
-        Long requesterId = 100L; // 요청자
-        Long ownerId = 200L;     // 실제 북마크 주인 (다름)
-        Long bookmarkId = 1L;
-
-        AuctionMember member = AuctionMember.builder().publicId(publicId).build();
-        ReflectionTestUtils.setField(member, "id", requesterId);
-
-        AuctionBookmark bookmark = AuctionBookmark.builder()
-                .memberId(ownerId) // 주인을 다르게 설정
-                .build();
-        ReflectionTestUtils.setField(bookmark, "id", bookmarkId);
-
-        given(auctionMemberRepository.findByPublicId(publicId))
-                .willReturn(Optional.of(member));
-
-        given(auctionBookmarkRepository.findById(bookmarkId))
-                .willReturn(Optional.of(bookmark));
-
-        // when & then
-        assertThatThrownBy(() -> auctionBookmarkUseCase.removeBookmark(publicId, bookmarkId))
-                .isInstanceOf(CustomException.class)
-                .satisfies(ex -> assertThat(((CustomException) ex).getErrorType())
-                        .isEqualTo(ErrorType.BOOKMARK_UNAUTHORIZED_ACCESS));
-
-        verify(auctionBookmarkRepository, never()).delete(any(AuctionBookmark.class));
-    }
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionReadUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionReadUseCaseTest.java
@@ -76,6 +76,7 @@ class AuctionReadUseCaseTest {
 		Long auctionId = 1L;
 		String memberPublicId = "user_pub_id_1";
 		Long memberId = 10L;
+		Long sellerId = 20L;
 
 		// 1. 회원 Mock
 		AuctionMember member = AuctionMember.builder().publicId(memberPublicId).build();
@@ -105,6 +106,19 @@ class AuctionReadUseCaseTest {
 		given(bidRepository.findTopByAuctionIdOrderByBidAmountDesc(auctionId)).willReturn(Optional.of(highestBid));
 		given(bidRepository.findTopByAuctionIdAndBidderIdOrderByBidAmountDesc(auctionId, memberId))
 			.willReturn(Optional.of(myLastBid));
+
+		ProductMember productSeller = ProductMember.builder().build();
+		ReflectionTestUtils.setField(productSeller, "id", sellerId);
+
+		// 4. 상품 정보
+		Product product = Product.builder().seller(productSeller).name("Test Item").build();
+		ReflectionTestUtils.setField(product, "id", 50L);
+
+		ProductImage image = ProductImage.builder().product(product).imageUrl("thumb.jpg").build();
+
+		// given
+		given(productRepository.findById(50L)).willReturn(Optional.of(product));
+		given(productImageRepository.findAllByProductId(50L)).willReturn(List.of(image));
 
 		// when
 		AuctionDetailResponseDto result = auctionReadUseCase.getAuctionDetail(auctionId, memberPublicId);

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/in/AuctionControllerTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/in/AuctionControllerTest.java
@@ -185,13 +185,13 @@ class AuctionControllerTest {
 				50L,
 				"Lego Product",
 				"Description",
-				"thumbnail.jpg",
+				List.of("thumbnail.jpg"),
 				AuctionStatus.IN_PROGRESS,
 				LocalDateTime.now(),
 				LocalDateTime.now().plusDays(1),
 				3600L,
 				new AuctionDetailResponseDto.PriceInfo(10000, 20000, 1000),
-				new AuctionDetailResponseDto.BidInfo(true, 21000, null, false),
+				new AuctionDetailResponseDto.BidInfo(true, 21000, null, false, false),
 				new AuctionDetailResponseDto.MyParticipationInfo(false, null));
 
 		// [수정] memberId(Long) -> memberPublicId(String)
@@ -316,32 +316,32 @@ class AuctionControllerTest {
 	@DisplayName("성공: 관심 경매 해제 시 HTTP 200과 해제 정보를 반환한다")
 	void removeBookmark_success() throws Exception {
 		// given
-		Long bookmarkId = 1L;
-		WishlistRemoveResponseDto responseDto = WishlistRemoveResponseDto.of(true, bookmarkId);
+		Long auctionId = 1L;
+		WishlistRemoveResponseDto responseDto = WishlistRemoveResponseDto.of(true, auctionId);
 
-		given(auctionFacade.removeBookmark(any(String.class), eq(bookmarkId)))
+		given(auctionFacade.removeBookmark(any(String.class), eq(auctionId)))
 				.willReturn(responseDto);
 
 		// when & then
-		mockMvc.perform(delete("/api/v1/auctions/{bookmarkId}/bookmarks", bookmarkId))
+		mockMvc.perform(delete("/api/v1/auctions/{auctionId}/bookmarks", auctionId))
 				.andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.status").value(200))
 				.andExpect(jsonPath("$.data.removed").value(true))
-				.andExpect(jsonPath("$.data.bookmarkId").value(bookmarkId));
+				.andExpect(jsonPath("$.data.auctionId").value(1L));
 	}
 
 	@Test
 	@DisplayName("실패: 관심 등록되지 않은 경매 해제 시 404를 반환한다")
 	void removeBookmark_fail_bookmark_not_found() throws Exception {
 		// given
-		Long bookmarkId = 1L;
+		Long auctionId = 1L;
 
-		given(auctionFacade.removeBookmark(any(String.class), eq(bookmarkId)))
+		given(auctionFacade.removeBookmark(any(String.class), eq(auctionId)))
 				.willThrow(new CustomException(ErrorType.BOOKMARK_NOT_FOUND));
 
 		// when & then
-		mockMvc.perform(delete("/api/v1/auctions/{bookmarkId}/bookmarks", bookmarkId))
+		mockMvc.perform(delete("/api/v1/auctions/{auctionId}/bookmarks", auctionId))
 				.andDo(print())
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.status").value(404));
@@ -352,13 +352,13 @@ class AuctionControllerTest {
 	// 새로 추가된 보안 로직 테스트
 	void removeBookmark_fail_unauthorized() throws Exception {
 		// given
-		Long bookmarkId = 1L;
+		Long auctionId = 1L;
 
-		given(auctionFacade.removeBookmark(any(String.class), eq(bookmarkId)))
+		given(auctionFacade.removeBookmark(any(String.class), eq(auctionId)))
 				.willThrow(new CustomException(ErrorType.BOOKMARK_UNAUTHORIZED_ACCESS));
 
 		// when & then
-		mockMvc.perform(delete("/api/v1/auctions/{bookmarkId}/bookmarks", bookmarkId))
+		mockMvc.perform(delete("/api/v1/auctions/{auctionId}/bookmarks", auctionId))
 				.andDo(print())
 				.andExpect(status().isForbidden()) // 403 Forbidden
 				.andExpect(jsonPath("$.status").value(403));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #199 

## 🚀 작업 내용
- [x] 경매 상세 조회 API에서 이름, 설명, 썸네일 직접 제공하도록 필드 추가
- [x] 경매 종료 시간(endTime)이나 현재가(currentPrice)가 null인 상태에서 에러가 발생하지 않도록 널 안정성 확보
- [x] 경매 위시리스트 삭제시 bookmarkId로 하던 것을 auctionId로 할 수 있도록 수정
## 🔍 리뷰 요청 사항 및 공유자료
<img width="1050" height="502" alt="image" src="https://github.com/user-attachments/assets/de0b5dab-600b-428a-91d3-503d0f693ff7" />

- 프론트 측에서 `bookmarkId`를 조회하거나 서버로부터 받아와서 들고 있어야 하는 문제가 있어서, 바로 처리할 수 있도록 `auctionId`로 변경했습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분