### PR TITLE
[FIX/product] 검수 화면 조회 url에 prefix 추가

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/product/app/ProductReadProductsForInspectionUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/product/app/ProductReadProductsForInspectionUseCase.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductReadProductsForInspectionUseCase {
 	private final ProductRepository productRepository;
+	private final ProductCreateS3PresignerUrlUseCase s3PresignerUrlUseCase;
 
 	@Transactional(readOnly = true)
 	public PagedResponseDto<ProductResponseForInspectionDto> readProducts(
@@ -24,6 +25,17 @@ public class ProductReadProductsForInspectionUseCase {
 		Page<ProductResponseForInspectionDto> productDtos = productRepository.
 			readProductsForAdmin(condition.name(), condition.category(), condition.status(), pageable);
 
-		return PagedResponseDto.from(productDtos);
+		return PagedResponseDto.from(productDtos, this::toPresignedDto);
+	}
+
+	private ProductResponseForInspectionDto toPresignedDto(ProductResponseForInspectionDto dto) {
+		return new ProductResponseForInspectionDto(
+			dto.ProductId(),
+			dto.name(),
+			dto.sellerEmail(),
+			dto.category(),
+			dto.inspectionStatus(),
+			s3PresignerUrlUseCase.getPresignedGetUrl(dto.thumbnail())
+		);
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #201

## 🚀 작업 내용
<img width="1057" height="431" alt="스크린샷 2026-01-25 오후 6 29 40" src="https://github.com/user-attachments/assets/8ce0eaba-faee-4a4a-8c72-56aa6159a8c2" />

- [x] /api/v1/products/inspections 조회 중 thumbnail에 s3 prefix 추가


## 🔍 리뷰 요청 사항 및 공유자료


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
1+
