### PR TITLE
[FEAT/payment] 정산 수수료 처리 리팩토링

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/domain/SettlementFee.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/domain/SettlementFee.java
@@ -1,0 +1,28 @@
+package com.bugzero.rarego.boundedContext.payment.domain;
+
+import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "PAYMENT_SETTLEMENT_FEE")
+public class SettlementFee extends BaseIdAndTime {
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(nullable = false, unique = true)
+	private Settlement settlement;
+
+	private int feeAmount;
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/event/SettlementFinishedEvent.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/event/SettlementFinishedEvent.java
@@ -1,0 +1,4 @@
+package com.bugzero.rarego.boundedContext.payment.event;
+
+public record SettlementFinishedEvent() {
+}

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentEventListener.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/PaymentEventListener.java
@@ -5,9 +5,12 @@ import static org.springframework.transaction.event.TransactionPhase.*;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.bugzero.rarego.boundedContext.payment.app.PaymentFacade;
+import com.bugzero.rarego.boundedContext.payment.app.PaymentSettlementProcessor;
+import com.bugzero.rarego.boundedContext.payment.event.SettlementFinishedEvent;
 import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
 import com.bugzero.rarego.shared.member.event.MemberJoinedEvent;
 import com.bugzero.rarego.shared.member.event.MemberUpdatedEvent;
@@ -19,25 +22,36 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class PaymentEventListener {
-    private final PaymentFacade paymentFacade;
+	private final PaymentFacade paymentFacade;
+	private final PaymentSettlementProcessor paymentSettlementProcessor;
 
-    // TODO: Spring Retry 추가 검토 (@Retryable)
-    @TransactionalEventListener(phase = AFTER_COMMIT)
-    @Transactional(propagation = REQUIRES_NEW)
-    public void handle(AuctionEndedEvent event) {
-        log.info("경매 종료 이벤트 수신: auctionId={}, winnerId={}", event.auctionId(), event.winnerId());
-        paymentFacade.releaseDeposits(event.auctionId(), event.winnerId());
-    }
+	// TODO: Spring Retry 추가 검토 (@Retryable)
+	@TransactionalEventListener(phase = AFTER_COMMIT)
+	@Transactional(propagation = REQUIRES_NEW)
+	public void handle(AuctionEndedEvent event) {
+		log.info("경매 종료 이벤트 수신: auctionId={}, winnerId={}", event.auctionId(), event.winnerId());
+		paymentFacade.releaseDeposits(event.auctionId(), event.winnerId());
+	}
 
-    @TransactionalEventListener(phase = AFTER_COMMIT)
-    @Transactional(propagation = REQUIRES_NEW)
-    public void onMemberCreated(MemberJoinedEvent event) {
-        paymentFacade.syncMember(event.memberDto());
-    }
+	@TransactionalEventListener(phase = AFTER_COMMIT)
+	@Transactional(propagation = REQUIRES_NEW)
+	public void onMemberCreated(MemberJoinedEvent event) {
+		paymentFacade.syncMember(event.memberDto());
+	}
 
-    @TransactionalEventListener(phase = AFTER_COMMIT)
-    @Transactional(propagation = REQUIRES_NEW)
-    public void onMemberUpdated(MemberUpdatedEvent event) {
-        paymentFacade.syncMember(event.memberDto());
-    }
+	@TransactionalEventListener(phase = AFTER_COMMIT)
+	@Transactional(propagation = REQUIRES_NEW)
+	public void onMemberUpdated(MemberUpdatedEvent event) {
+		paymentFacade.syncMember(event.memberDto());
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleSettlementFinished(SettlementFinishedEvent event) {
+		try {
+			// 기존과 동일하게 처리 (REQUIRES_NEW가 있어서 새 트랜잭션으로 돔)
+			paymentSettlementProcessor.processFees(1000);
+		} catch (Exception e) {
+			log.error("수수료 징수 중 에러 발생 (다음 배치에서 처리됨)", e);
+		}
+	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/in/SettlementBatchConfig.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/in/SettlementBatchConfig.java
@@ -2,6 +2,7 @@ package com.bugzero.rarego.boundedContext.payment.in;
 
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.partition.support.SimplePartitioner;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
@@ -9,6 +10,9 @@ import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import com.bugzero.rarego.boundedContext.payment.app.PaymentFacade;
 
@@ -20,18 +24,33 @@ public class SettlementBatchConfig {
 	@Value("${custom.payment.settlement.chunkSize:10}")
 	private int chunkSize;
 
+	private static final int THREAD_SIZE = 5;
+
 	private final PaymentFacade paymentFacade;
 	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;
 
 	@Bean
 	public Job settlementJob() {
 		return new JobBuilder("settlementJob", jobRepository)
-			.start(settlementProcessStep())
+			.start(mainStep())
 			.build();
 	}
 
+	// 작업을 분할하고 subStep에 스레드를 할당하여 실행
 	@Bean
-	public Step settlementProcessStep() {
+	public Step mainStep() {
+		return new StepBuilder("mainStep", jobRepository)
+			.partitioner("subStep", new SimplePartitioner()) // 작업을 복제
+			.step(subStep())
+			.gridSize(THREAD_SIZE)  // 스레드 생성
+			.taskExecutor(executor()) // 병렬 실행을 위한 스레드 풀
+			.build();
+	}
+
+	// 실제 정산 로직 수행
+	@Bean
+	public Step subStep() {
 		return new StepBuilder("settlementProcessStep", jobRepository)
 			.tasklet((contribution, chunkContext) -> {
 				int processedCount = paymentFacade.processSettlements(chunkSize);
@@ -43,6 +62,17 @@ public class SettlementBatchConfig {
 				contribution.incrementWriteCount(processedCount);
 
 				return RepeatStatus.CONTINUABLE;
-			}).build();
+			}, transactionManager).build();
+	}
+
+	// 정산 스레드 풀 설정
+	@Bean
+	public TaskExecutor executor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(THREAD_SIZE);
+		executor.setMaxPoolSize(THREAD_SIZE);
+		executor.setThreadNamePrefix("settlement-thread-");
+		executor.initialize();
+		return executor;
 	}
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/payment/out/SettlementFeeRepository.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/payment/out/SettlementFeeRepository.java
@@ -1,0 +1,20 @@
+package com.bugzero.rarego.boundedContext.payment.out;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.bugzero.rarego.boundedContext.payment.domain.SettlementFee;
+
+public interface SettlementFeeRepository extends JpaRepository<SettlementFee, Long> {
+	// SKIP LOCKED를 사용하여 다른 스레드가 처리 중인 데이터는 건너뛰고 조회
+	@Query(value = """
+		SELECT * FROM payment_settlement_fee
+		ORDER BY id ASC 
+		LIMIT :limit 
+		FOR UPDATE SKIP LOCKED
+		""", nativeQuery = true)
+	List<SettlementFee> findAllForBatch(@Param("limit") int limit);
+}

--- a/src/main/java/com/bugzero/rarego/global/response/SuccessResponseDto.java
+++ b/src/main/java/com/bugzero/rarego/global/response/SuccessResponseDto.java
@@ -1,7 +1,9 @@
 package com.bugzero.rarego.global.response;
 
 import com.bugzero.rarego.standard.response.ResponseDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SuccessResponseDto<T>(
 	Integer status,
 	String message,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,6 +6,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       auto-commit: false
+      maximum-pool-size: 20
+      minimum-idle: 20
 
   jpa:
     hibernate:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,9 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 20
 
   jpa:
     hibernate:

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentProcessSettlementUseCaseUnitTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentProcessSettlementUseCaseUnitTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -12,11 +13,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Pageable;
 
 import com.bugzero.rarego.boundedContext.payment.domain.Settlement;
 import com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus;
+import com.bugzero.rarego.boundedContext.payment.event.SettlementFinishedEvent;
 import com.bugzero.rarego.boundedContext.payment.out.SettlementRepository;
+import com.bugzero.rarego.global.event.EventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentProcessSettlementUseCaseUnitTest {
@@ -30,78 +32,108 @@ class PaymentProcessSettlementUseCaseUnitTest {
 	@Mock
 	private SettlementRepository settlementRepository;
 
+	@Mock
+	private EventPublisher eventPublisher;
+
 	@Test
-	@DisplayName("정상 흐름: 2건 모두 성공(true 반환) 시 판매자 입금 2회, 시스템 수수료 합산 입금 1회 호출")
+	@DisplayName("정상 흐름: 2건 모두 성공 시 - 판매자 처리 2회 후 이벤트 발행 확인")
 	void success_all() {
 		// given
-		Settlement s1 = createSettlement(1L, 1000);
-		Settlement s2 = createSettlement(2L, 2000);
+		Settlement s1 = createSettlement(1L);
+		Settlement s2 = createSettlement(2L);
 		List<Settlement> list = List.of(s1, s2);
 
-		given(settlementRepository.findSettlementsForBatch(eq(SettlementStatus.READY), any(), any(Pageable.class)))
+		given(settlementRepository.findSettlementsForBatch(eq(SettlementStatus.READY), any(), anyInt()))
 			.willReturn(list);
 
-		// ✅ boolean 반환에 맞춰 stubbing 수정
-		given(paymentSettlementProcessor.processSellerDeposit(anyLong())).willReturn(true);
+		given(paymentSettlementProcessor.processSellerDeposit(s1)).willReturn(true);
+		given(paymentSettlementProcessor.processSellerDeposit(s2)).willReturn(true);
 
 		// when
 		int count = useCase.processSettlements(10);
 
 		// then
 		assertThat(count).isEqualTo(2);
-		verify(paymentSettlementProcessor).processSellerDeposit(1L);
-		verify(paymentSettlementProcessor).processSellerDeposit(2L);
-		verify(paymentSettlementProcessor).processSystemDeposit(3000);
+
+		// 1. 판매자 정산 처리 호출 검증
+		verify(paymentSettlementProcessor).processSellerDeposit(s1);
+		verify(paymentSettlementProcessor).processSellerDeposit(s2);
+
+		// 2. [변경] 수수료 로직 직접 호출이 아닌, '이벤트 발행' 여부 검증
+		verify(eventPublisher).publish(any(SettlementFinishedEvent.class));
+
+		// (선택) 프로세서의 수수료 메서드는 UseCase에서 직접 호출되지 않음을 확인
+		verify(paymentSettlementProcessor, never()).processFees(anyInt());
 	}
 
 	@Test
-	@DisplayName("동시성 방어 검증: 프로세서가 false를 반환(이미 처리됨)하면 합산에서 제외됨")
+	@DisplayName("동시성 방어: 프로세서가 false를 반환하면 카운트되지 않지만, 이벤트는 발행됨")
 	void skip_if_processor_returns_false() {
 		// given
-		Settlement s1 = createSettlement(1L, 1000);
-		given(settlementRepository.findSettlementsForBatch(any(), any(), any()))
+		Settlement s1 = createSettlement(1L);
+		given(settlementRepository.findSettlementsForBatch(any(), any(), anyInt()))
 			.willReturn(List.of(s1));
 
-		// ✅ 다른 스레드가 먼저 처리하여 false가 반환되는 상황 시뮬레이션
-		given(paymentSettlementProcessor.processSellerDeposit(1L)).willReturn(false);
+		// 이미 처리된 건 등으로 인해 false 반환
+		given(paymentSettlementProcessor.processSellerDeposit(s1)).willReturn(false);
 
 		// when
 		int count = useCase.processSettlements(10);
 
 		// then
-		assertThat(count).isEqualTo(0); // 성공 카운트 0
-		verify(paymentSettlementProcessor, never()).processSystemDeposit(anyInt()); // 수수료 입금 호출 안됨
+		assertThat(count).isEqualTo(0);
+
+		// 처리 건수가 0이어도 마무리 이벤트는 발행되어야 함
+		verify(eventPublisher).publish(any(SettlementFinishedEvent.class));
 	}
 
 	@Test
-	@DisplayName("부분 성공: 1건 성공(true), 1건 실패(Exception) 시 성공한 건만 입금됨")
+	@DisplayName("부분 성공: 1건 성공, 1건 실패(예외) 시 - 실패 처리 후 이벤트 발행됨")
 	void partial_success() {
 		// given
-		Settlement successItem = createSettlement(1L, 1000);
-		Settlement failItem = createSettlement(2L, 2000);
+		Settlement successItem = createSettlement(1L);
+		Settlement failItem = createSettlement(2L);
 
-		given(settlementRepository.findSettlementsForBatch(eq(SettlementStatus.READY), any(), any(Pageable.class)))
+		given(settlementRepository.findSettlementsForBatch(any(), any(), anyInt()))
 			.willReturn(List.of(successItem, failItem));
 
-		// ✅ 1번은 성공(true), 2번은 예외 발생
-		given(paymentSettlementProcessor.processSellerDeposit(1L)).willReturn(true);
-		given(paymentSettlementProcessor.processSellerDeposit(2L)).willThrow(new RuntimeException("DB Lock"));
+		given(paymentSettlementProcessor.processSellerDeposit(successItem)).willReturn(true);
+		given(paymentSettlementProcessor.processSellerDeposit(failItem))
+			.willThrow(new RuntimeException("Something wrong"));
 
 		// when
 		int count = useCase.processSettlements(10);
 
 		// then
 		assertThat(count).isEqualTo(1);
-		verify(paymentSettlementProcessor).fail(2L);
-		verify(paymentSettlementProcessor).processSystemDeposit(1000);
+
+		// 실패 처리 검증
+		verify(failItem).fail();
+
+		// 예외가 발생했더라도 이벤트는 발행되어야 함
+		verify(eventPublisher).publish(any(SettlementFinishedEvent.class));
 	}
 
-	// empty_data, system_deposit_failure 테스트는 기존 로직(given/verify) 유지
+	@Test
+	@DisplayName("빈 데이터: 데이터가 없어도 수수료 처리(잔여분)를 위해 이벤트는 발행되어야 함")
+	void empty_data_but_publish_event() {
+		// given
+		given(settlementRepository.findSettlementsForBatch(any(), any(), anyInt()))
+			.willReturn(Collections.emptyList());
 
-	private Settlement createSettlement(Long id, int feeAmount) {
+		// when
+		int count = useCase.processSettlements(10);
+
+		// then
+		assertThat(count).isEqualTo(0);
+
+		// [중요] 빈 리스트여도 이벤트 발행 호출 확인
+		verify(eventPublisher).publish(any(SettlementFinishedEvent.class));
+	}
+
+	private Settlement createSettlement(Long id) {
 		Settlement settlement = mock(Settlement.class);
 		lenient().when(settlement.getId()).thenReturn(id);
-		lenient().when(settlement.getFeeAmount()).thenReturn(feeAmount);
 		return settlement;
 	}
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSettlementProcessorTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/payment/app/PaymentSettlementProcessorTest.java
@@ -3,6 +3,8 @@ package com.bugzero.rarego.boundedContext.payment.app;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,10 +18,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.bugzero.rarego.boundedContext.payment.domain.PaymentMember;
 import com.bugzero.rarego.boundedContext.payment.domain.PaymentTransaction;
 import com.bugzero.rarego.boundedContext.payment.domain.Settlement;
+import com.bugzero.rarego.boundedContext.payment.domain.SettlementFee;
 import com.bugzero.rarego.boundedContext.payment.domain.SettlementStatus;
 import com.bugzero.rarego.boundedContext.payment.domain.Wallet;
 import com.bugzero.rarego.boundedContext.payment.domain.WalletTransactionType;
 import com.bugzero.rarego.boundedContext.payment.out.PaymentTransactionRepository;
+import com.bugzero.rarego.boundedContext.payment.out.SettlementFeeRepository;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentSettlementProcessorTest {
@@ -32,6 +36,9 @@ class PaymentSettlementProcessorTest {
 	@Mock
 	private PaymentTransactionRepository paymentTransactionRepository;
 
+	@Mock // [New] 추가
+	private SettlementFeeRepository settlementFeeRepository;
+
 	@BeforeEach
 	void setUp() {
 		// @Value 주입을 위한 설정
@@ -39,74 +46,105 @@ class PaymentSettlementProcessorTest {
 	}
 
 	@Test
-	@DisplayName("processSellerDeposit 성공: 판매자에게 정산금(PAID) 입금 및 상태 완료 변경")
+	@DisplayName("processSellerDeposit 성공: 정산금 입금, 상태 완료, 수수료 대기열 저장까지 수행되어야 한다")
 	void processSellerDeposit_success() {
 		// given
-		Long settlementId = 1L;
 		Long sellerId = 100L;
 		int settlementAmount = 10000;
+		int feeAmount = 1000;
 
+		// Mock 객체 생성
 		Settlement settlement = mock(Settlement.class);
 		Wallet sellerWallet = mock(Wallet.class);
 		PaymentMember seller = mock(PaymentMember.class);
 
-		given(paymentSupport.findSettlementByIdForUpdate(settlementId)).willReturn(settlement);
+		// Stubbing (행위 정의)
 		given(settlement.getStatus()).willReturn(SettlementStatus.READY);
-		given(settlement.getId()).willReturn(settlementId);
 		given(settlement.getSettlementAmount()).willReturn(settlementAmount);
+		given(settlement.getFeeAmount()).willReturn(feeAmount); // 수수료 저장 위해 필요
 		given(settlement.getSeller()).willReturn(seller);
+
 		given(seller.getId()).willReturn(sellerId);
 
 		given(paymentSupport.findWalletByMemberIdForUpdate(sellerId)).willReturn(sellerWallet);
 		given(sellerWallet.getMember()).willReturn(seller);
 
 		// when
-		processor.processSellerDeposit(settlementId);
+		// [변경] ID 대신 엔티티 자체를 넘김
+		boolean result = processor.processSellerDeposit(settlement);
 
 		// then
+		assertThat(result).isTrue();
+
+		// 1. 지갑 잔액 증가 검증
 		verify(sellerWallet).addBalance(settlementAmount);
-		verify(settlement).complete(); // ✅ 상태 변경 확인 중요
-		verify(paymentTransactionRepository).save(any());
+
+		// 2. 정산 상태 완료 검증
+		verify(settlement).complete();
+
+		// 3. 트랜잭션 기록 저장 검증
+		verify(paymentTransactionRepository).save(any(PaymentTransaction.class));
+
+		// 4. [New] 수수료 대기열(SettlementFee) 저장 검증 (핵심)
+		ArgumentCaptor<SettlementFee> feeCaptor = ArgumentCaptor.forClass(SettlementFee.class);
+		verify(settlementFeeRepository).save(feeCaptor.capture());
+
+		assertThat(feeCaptor.getValue().getFeeAmount()).isEqualTo(feeAmount);
 	}
 
 	@Test
-	@DisplayName("processSystemDeposit 성공: 합산된 수수료를 시스템 지갑에 입금")
-	void processSystemDeposit_success() {
+	@DisplayName("processFees 성공: 대기열의 수수료를 합산하여 시스템 지갑에 입금하고 대기열을 비운다")
+	void processFees_success() {
 		// given
-		int totalFeeAmount = 5000;
+		int limit = 10;
 		Long systemMemberId = 2L;
+
+		// 수수료 데이터 2건 준비 (1000원, 2000원)
+		SettlementFee fee1 = mock(SettlementFee.class);
+		given(fee1.getFeeAmount()).willReturn(1000);
+
+		SettlementFee fee2 = mock(SettlementFee.class);
+		given(fee2.getFeeAmount()).willReturn(2000);
+
+		List<SettlementFee> fees = List.of(fee1, fee2);
+		int expectedTotalFee = 3000;
+
 		Wallet systemWallet = mock(Wallet.class);
 		PaymentMember systemMember = mock(PaymentMember.class);
 
+		// Stubbing
+		given(settlementFeeRepository.findAllForBatch(limit)).willReturn(fees);
 		given(paymentSupport.findWalletByMemberIdForUpdate(systemMemberId)).willReturn(systemWallet);
 		given(systemWallet.getMember()).willReturn(systemMember);
 
 		// when
-		processor.processSystemDeposit(totalFeeAmount);
+		processor.processFees(limit);
 
 		// then
-		verify(systemWallet).addBalance(totalFeeAmount);
+		// 1. 시스템 지갑에 합산 금액(3000원) 입금 확인
+		verify(systemWallet).addBalance(expectedTotalFee);
 
-		ArgumentCaptor<PaymentTransaction> captor = ArgumentCaptor.forClass(PaymentTransaction.class);
-		verify(paymentTransactionRepository).save(captor.capture());
+		// 2. 트랜잭션 기록 확인
+		ArgumentCaptor<PaymentTransaction> txCaptor = ArgumentCaptor.forClass(PaymentTransaction.class);
+		verify(paymentTransactionRepository).save(txCaptor.capture());
+		assertThat(txCaptor.getValue().getTransactionType()).isEqualTo(WalletTransactionType.SETTLEMENT_FEE);
+		assertThat(txCaptor.getValue().getBalanceDelta()).isEqualTo(expectedTotalFee);
 
-		assertThat(captor.getValue().getTransactionType()).isEqualTo(WalletTransactionType.SETTLEMENT_FEE);
-		assertThat(captor.getValue().getBalanceDelta()).isEqualTo(totalFeeAmount);
+		// 3. [New] 처리된 수수료 데이터 삭제 확인 (Queue 비우기)
+		verify(settlementFeeRepository).deleteAllInBatch(fees);
 	}
 
 	@Test
-	@DisplayName("fail 성공: 정산 상태가 READY인 경우에만 FAILED로 변경")
-	void fail_success() {
+	@DisplayName("processFees: 처리할 수수료가 없으면 아무 작업도 하지 않는다")
+	void processFees_empty() {
 		// given
-		Long settlementId = 1L;
-		Settlement settlement = mock(Settlement.class);
-		given(paymentSupport.findSettlementByIdForUpdate(settlementId)).willReturn(settlement);
-		given(settlement.getStatus()).willReturn(SettlementStatus.READY);
+		given(settlementFeeRepository.findAllForBatch(anyInt())).willReturn(List.of());
 
 		// when
-		processor.fail(settlementId);
+		processor.processFees(10);
 
 		// then
-		verify(settlement).fail();
+		verify(paymentSupport, never()).findWalletByMemberIdForUpdate(anyLong());
+		verify(settlementFeeRepository, never()).deleteAllInBatch(anyList());
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #215 

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

job를 실행하면 5개의 스레드로 step이 실행됩니다.
<img width="622" height="255" alt="image" src="https://github.com/user-attachments/assets/19de143d-d608-4ebb-9c3e-a6a20af0ff1c" />

- [ ] 정산 배치 멀티 스레딩 처리
- [ ] 수수료 정합성 보장 (메모리 합산 대신 DB 저장)
- [ ] 이벤트 기반 수수료 처리

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- skip locked를 도입해 lock을 이용해 동시성을 제어하면서도 대기하지 않게 최적화했습니다.
- 이벤트 기반 수수료 처리
  -  @TransactionalEventListener 도입: 정산 트랜잭션이 커밋되기 전에는 수수료 트랜잭션에서 데이터를 조회할 수 없는(Visibility) 문제를 해결했습니다.
  - AFTER_COMMIT 옵션을 사용하여, 정산 트랜잭션이 완전히 커밋된 직후에 수수료 징수 로직이 실행되도록 분리했습니다.
- 트러블슈팅 주말에 정리하겠습니다.

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
10분
