### PR TITLE
[REFACTOR/auction] 경매 낙찰 처리 리팩토링

### DIFF
--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleExpiredUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleExpiredUseCase.java
@@ -30,7 +30,7 @@ public class AuctionSettleExpiredUseCase {
         for (Auction auction : auctions) {
             try {
                 // 개별 트랜잭션 실행
-                support.processSettlement(auction);
+                support.processSettlement(auction.getId());
 
                 // 성공 결과 수집
                 if (support.hasBids(auction.getId())) {

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleExpiredUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleExpiredUseCase.java
@@ -1,18 +1,11 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
 import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
 import com.bugzero.rarego.boundedContext.auction.domain.Bid;
-import com.bugzero.rarego.boundedContext.auction.event.AuctionFailedEvent;
 import com.bugzero.rarego.boundedContext.auction.in.dto.AuctionAutoSettleResponseDto;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
-import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -24,11 +17,8 @@ import java.util.List;
 public class AuctionSettleExpiredUseCase {
 
     private final AuctionSettlementSupport support;
-    private final AuctionRepository auctionRepository;
-    private final AuctionOrderRepository auctionOrderRepository;
-    private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
+    // 전체 트랜잭션을 걸지 않음 (내부의 REQUIRES_NEW가 개별 관리하도록 함)
     public AuctionAutoSettleResponseDto execute() {
         LocalDateTime now = LocalDateTime.now();
         List<Auction> auctions = support.findExpiredAuctions(now);
@@ -39,59 +29,25 @@ public class AuctionSettleExpiredUseCase {
 
         for (Auction auction : auctions) {
             try {
+                // 개별 트랜잭션 실행
+                support.processSettlement(auction);
+
+                // 성공 결과 수집
                 if (support.hasBids(auction.getId())) {
-                    handleSuccess(auction);
                     Bid winningBid = support.findWinningBid(auction.getId());
                     details.add(AuctionAutoSettleResponseDto.SettlementDetail.success(
-                            auction.getId(),
-                            winningBid.getBidderId()));
-                    success++;
+                            auction.getId(), winningBid.getBidderId()));
                 } else {
-                    handleFail(auction);
                     details.add(AuctionAutoSettleResponseDto.SettlementDetail.failed(auction.getId()));
-                    fail++;
                 }
+                success++;
             } catch (Exception e) {
-                log.error("경매 낙찰 처리 실패 - auctionId: {}", auction.getId(), e);
+                log.error("경매 {} 정산 실패 - 다음 경매로 넘어갑니다.", auction.getId(), e);
+                details.add(AuctionAutoSettleResponseDto.SettlementDetail.failed(auction.getId()));
                 fail++;
             }
         }
 
         return AuctionAutoSettleResponseDto.from(now, auctions, success, fail, details);
-    }
-
-    private void handleFail(Auction auction) {
-        auction.end();
-        auctionRepository.save(auction);
-
-        eventPublisher.publishEvent(
-                new AuctionFailedEvent(
-                        auction.getId(),
-                        auction.getProductId()));
-    }
-
-    private void handleSuccess(Auction auction) {
-        Bid winningBid = support.findWinningBid(auction.getId());
-
-        auction.end();
-        auctionRepository.save(auction);
-
-        auctionOrderRepository.save(
-                AuctionOrder.builder()
-                        .auctionId(auction.getId())
-                        .sellerId(auction.getSellerId())
-                        .bidderId(winningBid.getBidderId())
-                        .finalPrice(winningBid.getBidAmount())
-                        .build()
-        );
-
-        eventPublisher.publishEvent(
-                new AuctionEndedEvent(
-                        auction.getId(),
-                        winningBid.getBidderId(),
-                        winningBid.getBidAmount(),
-                        auction.getProductId()
-                )
-        );
     }
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
@@ -33,7 +33,7 @@ public class AuctionSettleOneUseCase {
         validateAuctionSettlementEligibility(auction);
 
         // 정산 실행
-        support.processSettlement(auction);
+        support.processSettlement(auctionId);
         log.info("경매 {} 정산 처리 완료", auctionId);
     }
 

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
@@ -1,15 +1,11 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
-import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -20,31 +16,17 @@ public class AuctionSettleOneUseCase {
     private final AuctionSettlementSupport support;
 
     public void execute(Long auctionId) {
-        Auction auction = auctionRepository.findById(auctionId)
-                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
+        try {
+            support.processSettlement(auctionId);
+            log.info("경매 {} 정산 처리 완료", auctionId);
 
-        // 이미 종료된 경우: 로그만 남기고 'execute' 자체를 종료(Early Return)
-        if (auction.getStatus() == AuctionStatus.ENDED) {
-            log.warn("경매 {}는 이미 종료되었습니다.", auction.getId());
-            return;
-        }
-
-        // 그 외 비정상 상태 검증: 예외 발생
-        validateAuctionSettlementEligibility(auction);
-
-        // 정산 실행
-        support.processSettlement(auctionId);
-        log.info("경매 {} 정산 처리 완료", auctionId);
-    }
-
-    private void validateAuctionSettlementEligibility(Auction auction) {
-        // 진행 중이 아니거나 (SCHEDULED 등)
-        if (auction.getStatus() != AuctionStatus.IN_PROGRESS) {
-            throw new CustomException(ErrorType.AUCTION_NOT_IN_PROGRESS);
-        }
-        // 아직 시간이 안 된 경우
-        if (auction.getEndTime().isAfter(LocalDateTime.now())) {
-            throw new CustomException(ErrorType.AUCTION_NOT_IN_PROGRESS);
+        } catch (CustomException e) {
+            // 이미 다른 스레드에 의해 정산된 경우, 에러가 아닌 정상 흐름으로 간주
+            if (e.getErrorType() == ErrorType.AUCTION_NOT_FOUND_OR_ALREADY_SETTLED) {
+                log.warn("경매 {}는 이미 종료되었거나 정산 대상이 아닙니다.", auctionId);
+                return;
+            }
+            throw e;
         }
     }
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
@@ -1,20 +1,13 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
 import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
 import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
-import com.bugzero.rarego.boundedContext.auction.domain.Bid;
-import com.bugzero.rarego.boundedContext.auction.event.AuctionFailedEvent;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
-import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -23,77 +16,31 @@ import java.time.LocalDateTime;
 @Slf4j
 public class AuctionSettleOneUseCase {
 
-    private final AuctionSettlementSupport support;
     private final AuctionRepository auctionRepository;
-    private final AuctionOrderRepository auctionOrderRepository;
-    private final ApplicationEventPublisher eventPublisher;
+    private final AuctionSettlementSupport support;
 
-    @Transactional
     public void execute(Long auctionId) {
         Auction auction = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
 
-        // 상태 검증
+        // 검증 로직
+        validateAuctionStatus(auction);
+
+        // 정산 실행 (Support의 공통 로직 호출)
+        support.processSettlement(auction);
+        log.info("경매 {} 정산 처리 완료", auctionId);
+    }
+
+    private void validateAuctionStatus(Auction auction) {
         if (auction.getStatus() == AuctionStatus.ENDED) {
-            log.warn("경매 {}는 이미 종료되었습니다.", auctionId);
+            log.warn("경매 {}는 이미 종료되었습니다.", auction.getId());
             return;
         }
-
         if (auction.getStatus() != AuctionStatus.IN_PROGRESS) {
-            log.warn("경매 {}는 진행 중 상태가 아닙니다. 현재 상태: {}", auctionId, auction.getStatus());
             throw new CustomException(ErrorType.AUCTION_NOT_IN_PROGRESS);
         }
-
-        // 시간 검증
         if (auction.getEndTime().isAfter(LocalDateTime.now())) {
-            log.warn("경매 {}는 아직 종료 시간이 아닙니다. 종료 시간: {}", auctionId, auction.getEndTime());
             throw new CustomException(ErrorType.AUCTION_NOT_IN_PROGRESS);
         }
-
-        // 입찰 여부에 따라 처리
-        if (support.hasBids(auctionId)) {
-            handleSuccess(auction);
-            log.info("경매 {} 낙찰 처리 완료", auctionId);
-        } else {
-            handleFail(auction);
-            log.info("경매 {} 유찰 처리 완료", auctionId);
-        }
-    }
-
-    private void handleFail(Auction auction) {
-        auction.end();
-        auctionRepository.save(auction);
-
-        eventPublisher.publishEvent(
-                new AuctionFailedEvent(
-                        auction.getId(),
-                        auction.getProductId()
-                )
-        );
-    }
-
-    private void handleSuccess(Auction auction) {
-        Bid winningBid = support.findWinningBid(auction.getId());
-
-        auction.end();
-        auctionRepository.save(auction);
-
-        auctionOrderRepository.save(
-                AuctionOrder.builder()
-                        .auctionId(auction.getId())
-                        .sellerId(auction.getSellerId())
-                        .bidderId(winningBid.getBidderId())
-                        .finalPrice(winningBid.getBidAmount())
-                        .build()
-        );
-
-        eventPublisher.publishEvent(
-                new AuctionEndedEvent(
-                        auction.getId(),
-                        winningBid.getBidderId(),
-                        winningBid.getBidAmount(),
-                        auction.getProductId()
-                )
-        );
     }
 }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCase.java
@@ -23,22 +23,26 @@ public class AuctionSettleOneUseCase {
         Auction auction = auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
 
-        // 검증 로직
-        validateAuctionStatus(auction);
-
-        // 정산 실행 (Support의 공통 로직 호출)
-        support.processSettlement(auction);
-        log.info("경매 {} 정산 처리 완료", auctionId);
-    }
-
-    private void validateAuctionStatus(Auction auction) {
+        // 이미 종료된 경우: 로그만 남기고 'execute' 자체를 종료(Early Return)
         if (auction.getStatus() == AuctionStatus.ENDED) {
             log.warn("경매 {}는 이미 종료되었습니다.", auction.getId());
             return;
         }
+
+        // 그 외 비정상 상태 검증: 예외 발생
+        validateAuctionSettlementEligibility(auction);
+
+        // 정산 실행
+        support.processSettlement(auction);
+        log.info("경매 {} 정산 처리 완료", auctionId);
+    }
+
+    private void validateAuctionSettlementEligibility(Auction auction) {
+        // 진행 중이 아니거나 (SCHEDULED 등)
         if (auction.getStatus() != AuctionStatus.IN_PROGRESS) {
             throw new CustomException(ErrorType.AUCTION_NOT_IN_PROGRESS);
         }
+        // 아직 시간이 안 된 경우
         if (auction.getEndTime().isAfter(LocalDateTime.now())) {
             throw new CustomException(ErrorType.AUCTION_NOT_IN_PROGRESS);
         }

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
@@ -43,7 +43,14 @@ public class AuctionSettlementSupport {
      * 이 메서드는 독립적인 트랜잭션으로 실행되어, 호출부의 루프에서 에러가 나도 commit/rollback이 개별적으로 보장됨
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void processSettlement(Auction auction) {
+    public void processSettlement(Long auctionId) {
+
+        // 새로운 트랜잭션 안에서 최신 상태를 SELECT ... FOR UPDATE로 조회
+        // 만약 다른 스레드가 먼저 정산했다면, 여기서 조회되지 않거나(상태 필터링 시) 대기하게 됨
+        Auction auction = auctionRepository.findByIdWithLock(auctionId)
+                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND_OR_ALREADY_SETTLED));
+
+        // 최신화된 auction 객체로 정산 진행
         if (bidRepository.existsByAuctionId(auction.getId())) {
             handleSuccess(auction);
         } else {

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
@@ -1,14 +1,20 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
 import com.bugzero.rarego.boundedContext.auction.domain.Auction;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
 import com.bugzero.rarego.boundedContext.auction.domain.Bid;
+import com.bugzero.rarego.boundedContext.auction.event.AuctionFailedEvent;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
 import com.bugzero.rarego.boundedContext.auction.out.BidRepository;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
+import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -16,24 +22,80 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AuctionSettlementSupport {
 
     private final AuctionRepository auctionRepository;
     private final BidRepository bidRepository;
+    private final AuctionOrderRepository auctionOrderRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private static final int BATCH_SIZE = 100;
 
+    @Transactional(readOnly = true)
     public List<Auction> findExpiredAuctions(LocalDateTime now) {
         return auctionRepository.findExpiredInProgressAuctionsWithLock(
                 now, PageRequest.of(0, BATCH_SIZE)
         );
     }
 
+    /**
+     * 개별 경매 정산 로직 (트랜잭션 분리)
+     * 이 메서드는 독립적인 트랜잭션으로 실행되어, 호출부의 루프에서 에러가 나도 commit/rollback이 개별적으로 보장됨
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void processSettlement(Auction auction) {
+        if (bidRepository.existsByAuctionId(auction.getId())) {
+            handleSuccess(auction);
+        } else {
+            handleFail(auction);
+        }
+    }
+
+    private void handleSuccess(Auction auction) {
+        Bid winningBid = bidRepository.findTopByAuctionIdOrderByBidAmountDescBidTimeAsc(auction.getId())
+                .orElseThrow(() -> new CustomException(ErrorType.BID_NOT_FOUND));
+
+        auction.end();
+        auctionRepository.save(auction);
+
+        auctionOrderRepository.save(
+                AuctionOrder.builder()
+                        .auctionId(auction.getId())
+                        .sellerId(auction.getSellerId())
+                        .bidderId(winningBid.getBidderId())
+                        .finalPrice(winningBid.getBidAmount())
+                        .build()
+        );
+
+        eventPublisher.publishEvent(
+                new AuctionEndedEvent(
+                        auction.getId(),
+                        winningBid.getBidderId(),
+                        winningBid.getBidAmount(),
+                        auction.getProductId()
+                )
+        );
+    }
+
+    private void handleFail(Auction auction) {
+        auction.end();
+        auctionRepository.save(auction);
+
+        eventPublisher.publishEvent(
+                new AuctionFailedEvent(
+                        auction.getId(),
+                        auction.getProductId()
+                )
+        );
+    }
+
+    // 결과 조회를 위한 helper
+    @Transactional(readOnly = true)
     public boolean hasBids(Long auctionId) {
         return bidRepository.existsByAuctionId(auctionId);
     }
 
+    @Transactional(readOnly = true)
     public Bid findWinningBid(Long auctionId) {
         return bidRepository.findTopByAuctionIdOrderByBidAmountDescBidTimeAsc(auctionId)
                 .orElseThrow(() -> new CustomException(ErrorType.BID_NOT_FOUND));

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
@@ -39,26 +39,18 @@ public class AuctionSettlementSupport {
         );
     }
 
-    /**
-     * 개별 경매 정산 로직 (트랜잭션 분리)
-     * 이 메서드는 독립적인 트랜잭션으로 실행되어, 호출부의 루프에서 에러가 나도 commit/rollback이 개별적으로 보장됨
-     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processSettlement(Long auctionId) {
-
-        // 새로운 트랜잭션 안에서 최신 상태를 SELECT ... FOR UPDATE로 조회
-        // 만약 다른 스레드가 먼저 정산했다면, 여기서 조회되지 않거나(상태 필터링 시) 대기하게 됨
-        // 1. 비관적 락으로 조회
+        // 1. 비관적 락으로 조회: 다른 트랜잭션이 끝날 때까지 대기하여 최신 상태 보장
         Auction auction = auctionRepository.findByIdWithLock(auctionId)
                 .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
 
-        // 2. 이미 종료된 상태라면 예외를 던져 중복 처리를 방지
-        // 에러 코드 의미와 실제 상태 체크 로직을 일치시킴
+        // 2. 상태 검증: 진행 중이 아니라면 이미 다른 곳에서 정산/철회된 것임
         if (auction.getStatus() != AuctionStatus.IN_PROGRESS) {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND_OR_ALREADY_SETTLED);
         }
-        
-        // 최신화된 auction 객체로 정산 진행
+
+        // 3. 낙찰/유찰 처리
         if (bidRepository.existsByAuctionId(auction.getId())) {
             handleSuccess(auction);
         } else {

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
@@ -54,10 +54,10 @@ public class AuctionSettlementSupport {
 
         // 2. 이미 종료된 상태라면 예외를 던져 중복 처리를 방지
         // 에러 코드 의미와 실제 상태 체크 로직을 일치시킴
-        if (auction.getStatus() == AuctionStatus.ENDED) {
+        if (auction.getStatus() != AuctionStatus.IN_PROGRESS) {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND_OR_ALREADY_SETTLED);
         }
-
+        
         // 최신화된 auction 객체로 정산 진행
         if (bidRepository.existsByAuctionId(auction.getId())) {
             handleSuccess(auction);

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
@@ -2,6 +2,7 @@ package com.bugzero.rarego.boundedContext.auction.app;
 
 import com.bugzero.rarego.boundedContext.auction.domain.Auction;
 import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
 import com.bugzero.rarego.boundedContext.auction.domain.Bid;
 import com.bugzero.rarego.boundedContext.auction.event.AuctionFailedEvent;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
@@ -47,8 +48,15 @@ public class AuctionSettlementSupport {
 
         // 새로운 트랜잭션 안에서 최신 상태를 SELECT ... FOR UPDATE로 조회
         // 만약 다른 스레드가 먼저 정산했다면, 여기서 조회되지 않거나(상태 필터링 시) 대기하게 됨
+        // 1. 비관적 락으로 조회
         Auction auction = auctionRepository.findByIdWithLock(auctionId)
-                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND_OR_ALREADY_SETTLED));
+                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
+
+        // 2. 이미 종료된 상태라면 예외를 던져 중복 처리를 방지
+        // 에러 코드 의미와 실제 상태 체크 로직을 일치시킴
+        if (auction.getStatus() == AuctionStatus.ENDED) {
+            throw new CustomException(ErrorType.AUCTION_NOT_FOUND_OR_ALREADY_SETTLED);
+        }
 
         // 최신화된 auction 객체로 정산 진행
         if (bidRepository.existsByAuctionId(auction.getId())) {

--- a/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
+++ b/src/main/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupport.java
@@ -41,16 +41,21 @@ public class AuctionSettlementSupport {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processSettlement(Long auctionId) {
-        // 1. 비관적 락으로 조회: 다른 트랜잭션이 끝날 때까지 대기하여 최신 상태 보장
+        // 비관적 락으로 조회: 다른 트랜잭션이 끝날 때까지 대기하여 최신 상태 보장
         Auction auction = auctionRepository.findByIdWithLock(auctionId)
                 .orElseThrow(() -> new CustomException(ErrorType.AUCTION_NOT_FOUND));
 
-        // 2. 상태 검증: 진행 중이 아니라면 이미 다른 곳에서 정산/철회된 것임
+        // 상태 검증: 진행 중이 아니라면 이미 다른 곳에서 정산/철회된 것임
         if (auction.getStatus() != AuctionStatus.IN_PROGRESS) {
             throw new CustomException(ErrorType.AUCTION_NOT_FOUND_OR_ALREADY_SETTLED);
         }
 
-        // 3. 낙찰/유찰 처리
+        // 시간 검증
+        if (auction.getEndTime().isAfter(LocalDateTime.now())) {
+            throw new CustomException(ErrorType.AUCTION_NOT_FINISHED);
+        }
+
+        // 낙찰/유찰 처리
         if (bidRepository.existsByAuctionId(auction.getId())) {
             handleSuccess(auction);
         } else {

--- a/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
@@ -87,6 +87,7 @@ public enum ErrorType {
     AUCTION_WITHDRAW_NOT_INSPECTED(400, 2513, "검수 전 경매는 판매 포기할 수 없습니다."),
     BOOKMARK_UNAUTHORIZED_ACCESS(403, 2514, "요청한 사용자가 북마크의 memberId와 일치하지 않습니다."),
     AUCTION_NOT_FOUND_OR_ALREADY_SETTLED(404, 2515, "존재하지 않는 경매이거나 이미 정산이 완료된 경매입니다."),
+    AUCTION_NOT_FINISHED(400, 2516, "아직 경매 종료 시간이 되지 않아 정산할 수 없습니다."),
 
     // Product (3000 ~ 3999)
     PRODUCT_NOT_FOUND(404, 3001, "상품이 존재하지 않습니다."),

--- a/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
+++ b/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
@@ -1,10 +1,10 @@
 package com.bugzero.rarego.global.response;
 
-import java.util.Arrays;
-import java.util.Optional;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Getter
@@ -86,15 +86,16 @@ public enum ErrorType {
     AUCTION_WITHDRAW_PAYMENT_IN_PROGRESS(400, 2512, "결제 진행 중인 경매는 판매 포기할 수 없습니다."),
     AUCTION_WITHDRAW_NOT_INSPECTED(400, 2513, "검수 전 경매는 판매 포기할 수 없습니다."),
     BOOKMARK_UNAUTHORIZED_ACCESS(403, 2514, "요청한 사용자가 북마크의 memberId와 일치하지 않습니다."),
+    AUCTION_NOT_FOUND_OR_ALREADY_SETTLED(404, 2515, "존재하지 않는 경매이거나 이미 정산이 완료된 경매입니다."),
 
-	// Product (3000 ~ 3999)
-	PRODUCT_NOT_FOUND(404, 3001, "상품이 존재하지 않습니다."),
-	UNAUTHORIZED_SELLER(403, 3002, "해당 상품의 판매자가 아닙니다."),
-	IMAGE_NOT_FOUND(404, 3003, "해당 상품 이미지가 존재하지 않습니다."),
+    // Product (3000 ~ 3999)
+    PRODUCT_NOT_FOUND(404, 3001, "상품이 존재하지 않습니다."),
+    UNAUTHORIZED_SELLER(403, 3002, "해당 상품의 판매자가 아닙니다."),
+    IMAGE_NOT_FOUND(404, 3003, "해당 상품 이미지가 존재하지 않습니다."),
 
     INSPECTION_REJECT_REASON_REQUIRED(400, 3501, "검수 반려시 사유가 있어야 합니다."),
     INSPECTION_ALREADY_COMPLETED(400, 3502, "검수가 이미 완료된 상품입니다."),
-	INSPECTION_NOT_FOUND(404,3503, "해당 상품에 해당하는 검수 정보가 없습니다."),
+    INSPECTION_NOT_FOUND(404, 3503, "해당 상품에 해당하는 검수 정보가 없습니다."),
 
     // Payment (4000 ~ 4999)
     WALLET_NOT_FOUND(404, 4001, "회원의 지갑이 존재하지 않습니다."),
@@ -117,7 +118,8 @@ public enum ErrorType {
     DEPOSIT_NOT_FOUND(404, 4204, "보증금 정보를 찾을 수 없습니다."),
     ALREADY_USED_DEPOSIT(409, 4205, "이미 사용된 보증금입니다."),
     PAYMENT_DEADLINE_EXCEEDED(400, 4206, "결제 기한이 지났습니다."),
-    SETTLEMENT_ALREADY_COMPLETED(400, 4207, "이미 정산이 완료되어 환불할 수 없습니다.");
+    SETTLEMENT_ALREADY_COMPLETED(400, 4207, "이미 정산이 완료되어 환불할 수 없습니다."),
+    ;
 
     private final Integer httpStatus;
     private final int code;

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCaseTest.java
@@ -1,28 +1,21 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
 import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
 import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
-import com.bugzero.rarego.boundedContext.auction.domain.Bid;
-import com.bugzero.rarego.boundedContext.auction.event.AuctionFailedEvent;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
 import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
-import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
@@ -31,42 +24,31 @@ import static org.mockito.BDDMockito.*;
 class AuctionSettleOneUseCaseTest {
 
     @Mock
-    AuctionSettlementSupport support;
+    private AuctionRepository auctionRepository;
 
     @Mock
-    AuctionRepository auctionRepository;
-
-    @Mock
-    AuctionOrderRepository auctionOrderRepository;
-
-    @Mock
-    ApplicationEventPublisher eventPublisher;
+    private AuctionSettlementSupport support;
 
     @InjectMocks
-    AuctionSettleOneUseCase useCase;
+    private AuctionSettleOneUseCase useCase;
 
+    /**
+     * 테스트용 경매 객체 생성 헬퍼 메서드
+     */
     private Auction createAuction(Long id, AuctionStatus status, LocalDateTime endTime) {
         Auction auction = Auction.builder()
                 .productId(100L)
                 .sellerId(1L)
-                .startTime(LocalDateTime.now().minusHours(1))
+                .startTime(LocalDateTime.now().minusDays(1))
                 .endTime(endTime)
                 .startPrice(10_000)
-                .durationDays(1) // [dev 변경사항] 필드 추가
+                .durationDays(1) // 엔티티 생성자/빌더 NPE 방지를 위해 필수값 추가
                 .build();
 
         ReflectionTestUtils.setField(auction, "id", id);
         ReflectionTestUtils.setField(auction, "status", status);
 
         return auction;
-    }
-
-    private Bid createWinningBid(Long auctionId) {
-        return Bid.builder()
-                .auctionId(auctionId)
-                .bidderId(10L)
-                .bidAmount(50_000)
-                .build();
     }
 
     @Test
@@ -79,27 +61,29 @@ class AuctionSettleOneUseCaseTest {
         assertThatThrownBy(() -> useCase.execute(1L))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorType", ErrorType.AUCTION_NOT_FOUND);
+
+        // 정산 로직이 실행되지 않았음을 확인
+        verify(support, never()).processSettlement(any());
     }
 
     @Test
-    @DisplayName("이미 종료된 경매는 처리하지 않음")
+    @DisplayName("이미 종료된(ENDED) 경매는 아무런 처리를 하지 않고 리턴한다")
     void execute_AlreadyEnded() {
-        // given
+        // given: 이미 종료된 상태의 경매
         Auction auction = createAuction(1L, AuctionStatus.ENDED, LocalDateTime.now().minusHours(1));
         given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
 
         // when
         useCase.execute(1L);
 
-        // then
-        verify(auctionRepository, never()).save(any());
-        verify(eventPublisher, never()).publishEvent(any());
+        // then: support 호출이 절대 일어나지 않아야 함 (Early Return 확인)
+        verify(support, never()).processSettlement(any());
     }
 
     @Test
-    @DisplayName("진행 중이 아닌 경매는 예외 발생")
+    @DisplayName("진행 중(IN_PROGRESS)이 아닌 경매는 예외 발생")
     void execute_NotInProgress() {
-        // given
+        // given: 대기 중(SCHEDULED) 상태의 경매
         Auction auction = createAuction(1L, AuctionStatus.SCHEDULED, LocalDateTime.now().minusHours(1));
         given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
 
@@ -107,12 +91,14 @@ class AuctionSettleOneUseCaseTest {
         assertThatThrownBy(() -> useCase.execute(1L))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorType", ErrorType.AUCTION_NOT_IN_PROGRESS);
+
+        verify(support, never()).processSettlement(any());
     }
 
     @Test
-    @DisplayName("아직 종료 시간이 안 된 경매는 예외 발생")
+    @DisplayName("종료 시간(endTime)이 아직 지나지 않은 경매는 예외 발생")
     void execute_NotExpiredYet() {
-        // given
+        // given: 진행 중이지만 종료 시간이 미래인 경매
         Auction auction = createAuction(1L, AuctionStatus.IN_PROGRESS, LocalDateTime.now().plusHours(1));
         given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
 
@@ -120,43 +106,21 @@ class AuctionSettleOneUseCaseTest {
         assertThatThrownBy(() -> useCase.execute(1L))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorType", ErrorType.AUCTION_NOT_IN_PROGRESS);
+
+        verify(support, never()).processSettlement(any());
     }
 
     @Test
-    @DisplayName("입찰이 없으면 유찰 처리")
-    void execute_NoBids() {
-        // given
-        Auction auction = createAuction(1L, AuctionStatus.IN_PROGRESS, LocalDateTime.now().minusHours(1));
+    @DisplayName("검증을 모두 통과하면 Support를 통해 정산 처리를 수행한다")
+    void execute_Success() {
+        // given: 정산 가능한 조건의 경매
+        Auction auction = createAuction(1L, AuctionStatus.IN_PROGRESS, LocalDateTime.now().minusMinutes(1));
         given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
-        given(support.hasBids(1L)).willReturn(false);
 
         // when
         useCase.execute(1L);
 
-        // then
-        verify(auctionRepository).save(auction);
-        verify(eventPublisher).publishEvent(any(AuctionFailedEvent.class));
-        verify(auctionOrderRepository, never()).save(any());
-        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ENDED);
-    }
-
-    @Test
-    @DisplayName("입찰이 있으면 낙찰 처리")
-    void execute_WithBids() {
-        // given
-        Auction auction = createAuction(1L, AuctionStatus.IN_PROGRESS, LocalDateTime.now().minusHours(1));
-        Bid winningBid = createWinningBid(1L);
-        given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
-        given(support.hasBids(1L)).willReturn(true);
-        given(support.findWinningBid(1L)).willReturn(winningBid);
-
-        // when
-        useCase.execute(1L);
-
-        // then
-        verify(auctionRepository).save(auction);
-        verify(auctionOrderRepository).save(any(AuctionOrder.class));
-        verify(eventPublisher).publishEvent(any(AuctionEndedEvent.class));
-        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ENDED);
+        // then: 정산 핵심 로직이 1번 호출되었는지 확인
+        verify(support, times(1)).processSettlement(auction);
     }
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCaseTest.java
@@ -1,8 +1,5 @@
 package com.bugzero.rarego.boundedContext.auction.app;
 
-import com.bugzero.rarego.boundedContext.auction.domain.Auction;
-import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
-import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
 import org.junit.jupiter.api.DisplayName;
@@ -11,20 +8,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class AuctionSettleOneUseCaseTest {
-
-    @Mock
-    private AuctionRepository auctionRepository;
 
     @Mock
     private AuctionSettlementSupport support;
@@ -32,95 +22,56 @@ class AuctionSettleOneUseCaseTest {
     @InjectMocks
     private AuctionSettleOneUseCase useCase;
 
-    /**
-     * 테스트용 경매 객체 생성 헬퍼 메서드
-     */
-    private Auction createAuction(Long id, AuctionStatus status, LocalDateTime endTime) {
-        Auction auction = Auction.builder()
-                .productId(100L)
-                .sellerId(1L)
-                .startTime(LocalDateTime.now().minusDays(1))
-                .endTime(endTime)
-                .startPrice(10_000)
-                .durationDays(1) // 엔티티 생성자/빌더 NPE 방지를 위해 필수값 추가
-                .build();
+    @Test
+    @DisplayName("검증을 모두 통과하면 Support를 통해 정산 처리를 수행한다")
+    void execute_Success() {
+        // given
+        Long auctionId = 1L;
 
-        ReflectionTestUtils.setField(auction, "id", id);
-        ReflectionTestUtils.setField(auction, "status", status);
+        // when
+        useCase.execute(auctionId);
 
-        return auction;
+        // then
+        verify(support, times(1)).processSettlement(auctionId);
+    }
+
+    @Test
+    @DisplayName("이미 종료된(ENDED) 경매는 아무런 처리를 하지 않고 리턴한다")
+    void execute_AlreadyEnded() {
+        // given
+        Long auctionId = 1L;
+        doThrow(new CustomException(ErrorType.AUCTION_NOT_FOUND_OR_ALREADY_SETTLED))
+                .when(support).processSettlement(auctionId);
+
+        // when & then
+        assertThatCode(() -> useCase.execute(auctionId)).doesNotThrowAnyException();
+        verify(support).processSettlement(auctionId);
     }
 
     @Test
     @DisplayName("경매가 존재하지 않으면 예외 발생")
     void execute_AuctionNotFound() {
         // given
-        given(auctionRepository.findById(1L)).willReturn(Optional.empty());
+        Long auctionId = 1L;
+        doThrow(new CustomException(ErrorType.AUCTION_NOT_FOUND))
+                .when(support).processSettlement(auctionId);
 
         // when & then
-        assertThatThrownBy(() -> useCase.execute(1L))
+        assertThatThrownBy(() -> useCase.execute(auctionId))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorType", ErrorType.AUCTION_NOT_FOUND);
-
-        // 정산 로직이 실행되지 않았음을 확인
-        verify(support, never()).processSettlement(any());
-    }
-
-    @Test
-    @DisplayName("이미 종료된(ENDED) 경매는 아무런 처리를 하지 않고 리턴한다")
-    void execute_AlreadyEnded() {
-        // given: 이미 종료된 상태의 경매
-        Auction auction = createAuction(1L, AuctionStatus.ENDED, LocalDateTime.now().minusHours(1));
-        given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
-
-        // when
-        useCase.execute(1L);
-
-        // then: support 호출이 절대 일어나지 않아야 함 (Early Return 확인)
-        verify(support, never()).processSettlement(any());
     }
 
     @Test
     @DisplayName("진행 중(IN_PROGRESS)이 아닌 경매는 예외 발생")
     void execute_NotInProgress() {
-        // given: 대기 중(SCHEDULED) 상태의 경매
-        Auction auction = createAuction(1L, AuctionStatus.SCHEDULED, LocalDateTime.now().minusHours(1));
-        given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
+        // given
+        Long auctionId = 1L;
+        doThrow(new CustomException(ErrorType.AUCTION_NOT_IN_PROGRESS))
+                .when(support).processSettlement(auctionId);
 
         // when & then
-        assertThatThrownBy(() -> useCase.execute(1L))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorType", ErrorType.AUCTION_NOT_IN_PROGRESS);
-
-        verify(support, never()).processSettlement(any());
-    }
-
-    @Test
-    @DisplayName("종료 시간(endTime)이 아직 지나지 않은 경매는 예외 발생")
-    void execute_NotExpiredYet() {
-        // given: 진행 중이지만 종료 시간이 미래인 경매
-        Auction auction = createAuction(1L, AuctionStatus.IN_PROGRESS, LocalDateTime.now().plusHours(1));
-        given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
-
-        // when & then
-        assertThatThrownBy(() -> useCase.execute(1L))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorType", ErrorType.AUCTION_NOT_IN_PROGRESS);
-
-        verify(support, never()).processSettlement(any());
-    }
-
-    @Test
-    @DisplayName("검증을 모두 통과하면 Support를 통해 정산 처리를 수행한다")
-    void execute_Success() {
-        // given: 정산 가능한 조건의 경매
-        Auction auction = createAuction(1L, AuctionStatus.IN_PROGRESS, LocalDateTime.now().minusMinutes(1));
-        given(auctionRepository.findById(1L)).willReturn(Optional.of(auction));
-
-        // when
-        useCase.execute(1L);
-
-        // then: 정산 핵심 로직이 1번 호출되었는지 확인
-        verify(support, times(1)).processSettlement(auction.getId());
+        assertThatThrownBy(() -> useCase.execute(auctionId))
+                .isInstanceOf(CustomException.class);
     }
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCaseTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettleOneUseCaseTest.java
@@ -121,6 +121,6 @@ class AuctionSettleOneUseCaseTest {
         useCase.execute(1L);
 
         // then: 정산 핵심 로직이 1번 호출되었는지 확인
-        verify(support, times(1)).processSettlement(auction);
+        verify(support, times(1)).processSettlement(auction.getId());
     }
 }

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupportTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupportTest.java
@@ -1,0 +1,107 @@
+package com.bugzero.rarego.boundedContext.auction.app;
+
+import com.bugzero.rarego.boundedContext.auction.domain.Auction;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionOrder;
+import com.bugzero.rarego.boundedContext.auction.domain.AuctionStatus;
+import com.bugzero.rarego.boundedContext.auction.domain.Bid;
+import com.bugzero.rarego.boundedContext.auction.event.AuctionFailedEvent;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionOrderRepository;
+import com.bugzero.rarego.boundedContext.auction.out.AuctionRepository;
+import com.bugzero.rarego.boundedContext.auction.out.BidRepository;
+import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuctionSettlementSupportTest {
+
+    // 1. 필요한 모든 의존성을 @Mock으로 선언합니다.
+    @Mock
+    private AuctionRepository auctionRepository;
+
+    @Mock
+    private BidRepository bidRepository;
+
+    @Mock
+    private AuctionOrderRepository auctionOrderRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    // 2. 위 Mock들을 주입받을 대상입니다.
+    @InjectMocks
+    private AuctionSettlementSupport support;
+
+    private Auction auction;
+
+    @BeforeEach
+    void setUp() {
+        // Auction 객체 생성 시 durationDays 등 필수 필드 누락 주의!
+        auction = Auction.builder()
+                .sellerId(1L)
+                .productId(100L)
+                .startPrice(10000)
+                .durationDays(1)
+                .startTime(LocalDateTime.now().minusDays(1))
+                .endTime(LocalDateTime.now().minusMinutes(1))
+                .build();
+
+        ReflectionTestUtils.setField(auction, "id", 1L);
+        ReflectionTestUtils.setField(auction, "status", AuctionStatus.IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("입찰자가 있는 경우: 낙찰 처리되고 주문이 생성된다")
+    void processSettlement_success_with_bid() {
+        // given
+        Bid winningBid = Bid.builder()
+                .bidderId(10L)
+                .bidAmount(50000)
+                .build();
+
+        given(bidRepository.existsByAuctionId(1L)).willReturn(true);
+        given(bidRepository.findTopByAuctionIdOrderByBidAmountDescBidTimeAsc(1L))
+                .willReturn(Optional.of(winningBid));
+
+        // when
+        support.processSettlement(auction);
+
+        // then
+        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ENDED);
+        verify(auctionRepository).save(auction); // 이 부분이 null이 아니어야 함
+        verify(auctionOrderRepository).save(any(AuctionOrder.class));
+        verify(eventPublisher).publishEvent(any(AuctionEndedEvent.class));
+    }
+
+    @Test
+    @DisplayName("입찰자가 없는 경우: 유찰 처리되고 실패 이벤트가 발행된다")
+    void processSettlement_fail_no_bid() {
+        // given
+        given(bidRepository.existsByAuctionId(1L)).willReturn(false);
+
+        // when
+        support.processSettlement(auction);
+
+        // then
+        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ENDED);
+        verify(auctionRepository).save(auction);
+        verify(auctionOrderRepository, never()).save(any());
+        verify(eventPublisher).publishEvent(any(AuctionFailedEvent.class));
+    }
+}

--- a/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupportTest.java
+++ b/src/test/java/com/bugzero/rarego/boundedContext/auction/app/AuctionSettlementSupportTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class AuctionSettlementSupportTest {
 
-    // 1. 필요한 모든 의존성을 @Mock으로 선언합니다.
     @Mock
     private AuctionRepository auctionRepository;
 
@@ -44,7 +43,6 @@ class AuctionSettlementSupportTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
-    // 2. 위 Mock들을 주입받을 대상입니다.
     @InjectMocks
     private AuctionSettlementSupport support;
 
@@ -52,7 +50,6 @@ class AuctionSettlementSupportTest {
 
     @BeforeEach
     void setUp() {
-        // Auction 객체 생성 시 durationDays 등 필수 필드 누락 주의!
         auction = Auction.builder()
                 .sellerId(1L)
                 .productId(100L)
@@ -70,21 +67,24 @@ class AuctionSettlementSupportTest {
     @DisplayName("입찰자가 있는 경우: 낙찰 처리되고 주문이 생성된다")
     void processSettlement_success_with_bid() {
         // given
+        Long auctionId = 1L;
         Bid winningBid = Bid.builder()
                 .bidderId(10L)
                 .bidAmount(50000)
                 .build();
 
-        given(bidRepository.existsByAuctionId(1L)).willReturn(true);
-        given(bidRepository.findTopByAuctionIdOrderByBidAmountDescBidTimeAsc(1L))
+        given(auctionRepository.findByIdWithLock(auctionId)).willReturn(Optional.of(auction));
+
+        given(bidRepository.existsByAuctionId(auctionId)).willReturn(true);
+        given(bidRepository.findTopByAuctionIdOrderByBidAmountDescBidTimeAsc(auctionId))
                 .willReturn(Optional.of(winningBid));
 
         // when
-        support.processSettlement(auction);
+        support.processSettlement(auctionId);
 
         // then
         assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ENDED);
-        verify(auctionRepository).save(auction); // 이 부분이 null이 아니어야 함
+        verify(auctionRepository).save(auction);
         verify(auctionOrderRepository).save(any(AuctionOrder.class));
         verify(eventPublisher).publishEvent(any(AuctionEndedEvent.class));
     }
@@ -93,10 +93,14 @@ class AuctionSettlementSupportTest {
     @DisplayName("입찰자가 없는 경우: 유찰 처리되고 실패 이벤트가 발행된다")
     void processSettlement_fail_no_bid() {
         // given
-        given(bidRepository.existsByAuctionId(1L)).willReturn(false);
+        Long auctionId = 1L;
+
+        given(auctionRepository.findByIdWithLock(auctionId)).willReturn(Optional.of(auction));
+
+        given(bidRepository.existsByAuctionId(auctionId)).willReturn(false);
 
         // when
-        support.processSettlement(auction);
+        support.processSettlement(auctionId);
 
         // then
         assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ENDED);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #246 

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

### 주요 변경 사항
1. 트랜잭션 원자성 해결 (REQUIRES_NEW)
기존에는 일괄 정산 시 하나만 에러가 나도 전체가 롤백되는 리스크가 있었습니다.
개별 정산 단위를 독립적인 트랜잭션으로 분리하여, 특정 경매 정산 실패가 다른 경매에 영향을 주지 않도록 개선했습니다.

2. 코드 중복 제거 및 책임 분리
ExpiredUseCase와 SettleOneUseCase에 흩어져 있던 낙찰/유찰 처리 로직을 AuctionSettlementSupport로 모아 공통화했습니다. 

3. 에러 핸들링 강화
루프 내부에서 try-catch를 통해 예외를 개별 제어함으로써, 대규모 정산 작업의 중단 없는 실행을 보장합니다.

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
5