### PR TITLE
[REFACTOR/infra] 내부 서비스 통신용 URL 설정 방식 리팩토링 및 환경 변수 분리

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -160,7 +160,7 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
           source: "docker-compose.yml,docker"
-          target: "~/app"
+          target: "~/beadv4_4_BugZero_BE"
 
       - name: Deploy to EC2 via SSH
         uses: appleboy/ssh-action@v1.0.3
@@ -172,8 +172,8 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
           script: |
-            mkdir -p ~/app
-            cd ~/app
+            mkdir -p ~/beadv4_4_BugZero_BE
+            cd ~/beadv4_4_BugZero_BE
             
             # .env.deploy 파일 초기화 및 환경 변수 주입
             echo "PAYMENT_DOCKER_IMAGE=${{ env.REGISTRY }}/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-payment-service:${{ github.ref_name }}" > .env.deploy
@@ -193,7 +193,6 @@ jobs:
             echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env.deploy
             echo "AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}" >> .env.deploy
             echo "AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}" >> .env.deploy
-            echo "INTERNAL_BACK_URL=${{ secrets.INTERNAL_BACK_URL }}" >> .env.deploy
             echo "FRONT_URL=${{ secrets.FRONT_URL }}" >> .env.deploy
             echo "GRAFANA_ADMIN_USER=${{ secrets.GRAFANA_ADMIN_USER }}" >> .env.deploy
             echo "GRAFANA_ADMIN_PASSWORD=${{ secrets.GRAFANA_ADMIN_PASSWORD }}" >> .env.deploy

--- a/auction-service/src/main/resources/application.yml
+++ b/auction-service/src/main/resources/application.yml
@@ -103,7 +103,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
   payment:
     settlement:
       chunkSize: 10

--- a/auction-service/src/test/resources/application.yml
+++ b/auction-service/src/test/resources/application.yml
@@ -55,7 +55,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
     frontUrl: ${FRONT_URL:http://localhost:3000}
   payment:
     settlement:

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -103,7 +103,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
   payment:
     settlement:
       chunkSize: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      INTERNAL_BACK_URL: ${INTERNAL_BACK_URL:-http://auction-service:8083}
+      INTERNAL_BACK_URL: http://rarego-nginx
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
       TZ: Asia/Seoul
 
@@ -98,7 +98,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      INTERNAL_BACK_URL: ${INTERNAL_BACK_URL:-http://member-service:8081}
+      INTERNAL_BACK_URL: http://rarego-nginx
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
       TZ: Asia/Seoul
 
@@ -136,7 +136,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      INTERNAL_BACK_URL: ${INTERNAL_BACK_URL:-http://auth-service:8089}
+      INTERNAL_BACK_URL: http://rarego-nginx
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
       TZ: Asia/Seoul
 
@@ -174,7 +174,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      INTERNAL_BACK_URL: ${INTERNAL_BACK_URL:-http://member-service:8081}
+      INTERNAL_BACK_URL: http://rarego-nginx
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
       TZ: Asia/Seoul
 
@@ -212,7 +212,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      INTERNAL_BACK_URL: ${INTERNAL_BACK_URL:-http://auction-service:8083}
+      INTERNAL_BACK_URL: http://rarego-nginx
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
       TZ: Asia/Seoul
 
@@ -246,7 +246,7 @@ services:
       JWT_SECRET: ${JWT_SECRET:-dev-secret-key-have-to-change-abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz}
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      INTERNAL_BACK_URL: ${INTERNAL_BACK_URL:-http://member-service:8081}
+      INTERNAL_BACK_URL: http://rarego-nginx
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
       TZ: Asia/Seoul
 

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -91,6 +91,45 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # ========== Internal APIs (서비스 간 내부 통신 전용) ==========
+    # 외부 도메인(rarego.duckdns.org)에서는 접근 불가, 내부 게이트웨이(rarego-nginx)만 허용
+
+    location /api/v1/internal/members {
+        if ($host = "rarego.duckdns.org") {
+            return 403;
+        }
+        proxy_pass http://member-service:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/v1/internal/auctions {
+        if ($host = "rarego.duckdns.org") {
+            return 403;
+        }
+        proxy_pass http://auction-service:8083;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/v1/internal/payments {
+        if ($host = "rarego.duckdns.org") {
+            return 403;
+        }
+        proxy_pass http://payment-service:8082;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Swagger / API Docs
     location ~ ^/(api-docs|swagger-ui|v3/api-docs) {
         # Default to auth-service for docs or pick one

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,5 +1,24 @@
 server {
-    server_name rarego.duckdns.org;
+    listen 80;
+    listen 443 ssl;
+    server_name rarego.duckdns.org rarego-nginx;
+
+    # SSL settings (only active for HTTPS)
+    ssl_certificate /etc/letsencrypt/live/rarego.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/rarego.duckdns.org/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # HTTP to HTTPS Redirect for External Domain Only
+    if ($host = "rarego.duckdns.org") {
+        set $do_redirect "Y";
+    }
+    if ($server_port = "80") {
+        set $do_redirect "${do_redirect}Y";
+    }
+    if ($do_redirect = "YY") {
+        return 301 https://$host$request_uri;
+    }
 
     location /.well-known/acme-challenge/ {
         root /var/lib/letsencrypt;
@@ -97,8 +116,6 @@ server {
 
         proxy_pass http://grafana:3000/;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Prometheus
@@ -108,24 +125,5 @@ server {
 
         proxy_pass http://prometheus:9090/;
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
     }
-
-    listen 443 ssl;
-    ssl_certificate /etc/letsencrypt/live/rarego.duckdns.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/rarego.duckdns.org/privkey.pem;
-    include /etc/letsencrypt/options-ssl-nginx.conf;
-    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-}
-
-server {
-    listen 80;
-    server_name rarego.duckdns.org;
-
-    location /.well-known/acme-challenge/ {
-        root /var/lib/letsencrypt;
-    }
-
-    return 301 https://$host$request_uri;
 }

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,7 +1,7 @@
+# ========== 외부 전용 서버 블록 (443 SSL) ==========
 server {
-    listen 80;
     listen 443 ssl;
-    server_name rarego.duckdns.org rarego-nginx;
+    server_name rarego.duckdns.org;
 
     # SSL settings (only active for HTTPS)
     ssl_certificate /etc/letsencrypt/live/rarego.duckdns.org/fullchain.pem;
@@ -9,20 +9,125 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    # HTTP to HTTPS Redirect for External Domain Only
-    if ($host = "rarego.duckdns.org") {
-        set $do_redirect "Y";
+    # Auth Service
+    location ~ ^/(api/v1/auth|oauth2|login/oauth2) {
+        proxy_pass http://auth-service:8089;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
-    if ($server_port = "80") {
-        set $do_redirect "${do_redirect}Y";
+
+    # Auction Service (Specific Member activities)
+    location ~ ^/api/v1/members/me/(bids|sales|orders|bookmarks) {
+        proxy_pass http://auction-service:8083;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
-    if ($do_redirect = "YY") {
-        return 301 https://$host$request_uri;
+
+    # Auction Service
+    location /api/v1/auctions {
+        proxy_pass http://auction-service:8083;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # SSE (Bid Stream)
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding off;
+        proxy_read_timeout 86400s;
     }
+
+    # Payment Service
+    location /api/v1/payments {
+        proxy_pass http://payment-service:8082;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Product Service
+    location /api/v1/products {
+        proxy_pass http://product-service:8084;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Member Service (General)
+    location /api/v1/members {
+        proxy_pass http://member-service:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Swagger / API Docs
+    location ~ ^/(api-docs|swagger-ui|v3/api-docs) {
+        proxy_pass http://auth-service:8089;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    # Frontend (Next.js)
+    location / {
+        proxy_pass http://host.docker.internal:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Grafana
+    location /grafana/ {
+        auth_basic "Monitoring";
+        auth_basic_user_file /etc/nginx/.htpasswd-monitoring;
+
+        proxy_pass http://grafana:3000/;
+        proxy_set_header Host $host;
+    }
+
+    # Prometheus
+    location /prometheus/ {
+        auth_basic "Monitoring";
+        auth_basic_user_file /etc/nginx/.htpasswd-monitoring;
+
+        proxy_pass http://prometheus:9090/;
+        proxy_set_header Host $host;
+    }
+}
+
+# ========== HTTP to HTTPS 리다이렉트 (외부 도메인) ==========
+server {
+    listen 80;
+    server_name rarego.duckdns.org;
 
     location /.well-known/acme-challenge/ {
         root /var/lib/letsencrypt;
     }
+
+    return 301 https://$host$request_uri;
+}
+
+# ========== 내부 전용 서버 블록 (80 포트, 도커 네트워크 내부만) ==========
+server {
+    listen 80;
+    server_name rarego-nginx;
 
     # Auth Service
     location ~ ^/(api/v1/auth|oauth2|login/oauth2) {
@@ -95,9 +200,6 @@ server {
     # 외부 도메인(rarego.duckdns.org)에서는 접근 불가, 내부 게이트웨이(rarego-nginx)만 허용
 
     location /api/v1/internal/members {
-        if ($host = "rarego.duckdns.org") {
-            return 403;
-        }
         proxy_pass http://member-service:8081;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -107,9 +209,6 @@ server {
     }
 
     location /api/v1/internal/auctions {
-        if ($host = "rarego.duckdns.org") {
-            return 403;
-        }
         proxy_pass http://auction-service:8083;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -119,50 +218,11 @@ server {
     }
 
     location /api/v1/internal/payments {
-        if ($host = "rarego.duckdns.org") {
-            return 403;
-        }
         proxy_pass http://payment-service:8082;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # Swagger / API Docs
-    location ~ ^/(api-docs|swagger-ui|v3/api-docs) {
-        # Default to auth-service for docs or pick one
-        proxy_pass http://auth-service:8089;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-    }
-
-    # Frontend (Next.js) - running on EC2 host:3000
-    location / {
-        proxy_pass http://host.docker.internal:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
-    }
-
-    # Grafana
-    location /grafana/ {
-        auth_basic "Monitoring";
-        auth_basic_user_file /etc/nginx/.htpasswd-monitoring;
-
-        proxy_pass http://grafana:3000/;
-        proxy_set_header Host $host;
-    }
-
-    # Prometheus
-    location /prometheus/ {
-        auth_basic "Monitoring";
-        auth_basic_user_file /etc/nginx/.htpasswd-monitoring;
-
-        proxy_pass http://prometheus:9090/;
-        proxy_set_header Host $host;
     }
 }

--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -69,6 +69,34 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # ========== Internal APIs (서비스 간 내부 통신 전용) ==========
+    location /api/v1/internal/members {
+        proxy_pass http://member-service:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/v1/internal/auctions {
+        proxy_pass http://auction-service:8083;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/v1/internal/payments {
+        proxy_pass http://payment-service:8082;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Swagger / API Docs
     location ~ ^/(api-docs|swagger-ui|v3/api-docs) {
         proxy_pass http://auth-service:8089;

--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name localhost;
+    server_name localhost rarego-nginx;
 
     # Auth Service
     location ~ ^/(api/v1/auth|oauth2|login/oauth2) {

--- a/member-service/src/main/resources/application.yml
+++ b/member-service/src/main/resources/application.yml
@@ -82,7 +82,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
   payment:
     settlement:
       chunkSize: 10

--- a/member-service/src/test/resources/application.yml
+++ b/member-service/src/test/resources/application.yml
@@ -28,6 +28,6 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
     frontUrl: ${FRONT_URL:http://localhost:3000}
 

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -71,9 +71,9 @@ springdoc:
 
 custom:
   services:
-    auth-url: http://localhost:8080
-    member-url: http://localhost:8081
-    payment-url: http://localhost:8082
-    auction-url: http://localhost:8083
-    product-url: http://localhost:8084
-    notification-url: http://localhost:8085
+    auth-url: http://rarego-nginx
+    member-url: http://rarego-nginx
+    payment-url: http://rarego-nginx
+    auction-url: http://rarego-nginx
+    product-url: http://rarego-nginx
+    notification-url: http://rarego-nginx

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -82,7 +82,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
   payment:
     settlement:
       chunkSize: 10

--- a/payment-service/src/test/resources/application.yml
+++ b/payment-service/src/test/resources/application.yml
@@ -50,7 +50,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
     frontUrl: ${FRONT_URL:http://localhost:3000}
   payment:
     settlement:

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -65,7 +65,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
   payment:
     settlement:
       chunkSize: 10

--- a/product-service/src/test/resources/application.yml
+++ b/product-service/src/test/resources/application.yml
@@ -71,7 +71,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
     frontUrl: ${FRONT_URL:http://localhost:3000}
   payment:
     settlement:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,7 +103,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
   payment:
     settlement:
       chunkSize: 10

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -55,7 +55,7 @@ jwt:
 
 custom:
   global:
-    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:8080}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://rarego-nginx}
     frontUrl: ${FRONT_URL:http://localhost:3000}
   payment:
     settlement:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #299 

## 🚀 작업 내용
- [x] 공유 환경 변수 INTERNAL_BACK_URL을 http://rarego-nginx로 설정
- [x] docker-compose.yml 내 서비스별 환경 변수 설정 최적화 및 기본값(도커 DNS) 적용
- [x] 각 마이크로서비스의 application.yml에서 새 환경 변수를 매핑하도록 수정
- [x] cicd.yml INTERNAL_BACK_URL 주입 로직 제거

## 🔍 리뷰 요청 사항 및 공유자료
- Nginx 내부 게이트웨이 도입: 모든 서비스가 서로의 포트를 직접 알 필요 없이 http://rarego-nginx를 통해 통신하도록 리팩토링했습니다.
- cicd.yml에서 EC2 배포 경로를 ~/beadv4_4_BugZero_BE로 통일하고 불필요한 URL 주입 로직을 제거했습니다.

- 추후 Resilience4j를 이용해 통신 장애 전파를 막는 서킷 브레이커를 도입하면 좋을 것 같습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분