### PR TITLE
[FEAT/payment] AuctionPaymentExpiringSoonEvent 카프카 발행

### DIFF
--- a/auction-service/src/main/java/com/bugzero/rarego/app/AuctionOrderService.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/app/AuctionOrderService.java
@@ -6,58 +6,77 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.bugzero.rarego.domain.AuctionOrder;
 import com.bugzero.rarego.domain.AuctionOrderStatus;
-import com.bugzero.rarego.out.AuctionOrderRepository;
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
+import com.bugzero.rarego.out.AuctionOrderRepository;
 import com.bugzero.rarego.shared.auction.dto.AuctionOrderDto;
+
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class AuctionOrderService {
-    private final AuctionOrderRepository auctionOrderRepository;
+	private final AuctionOrderRepository auctionOrderRepository;
 
-    public Optional<AuctionOrderDto> findByAuctionId(Long auctionId) {
-        return auctionOrderRepository.findByAuctionId(auctionId)
-                .map(this::from);
-    }
+	public Optional<AuctionOrderDto> findByAuctionId(Long auctionId) {
+		return auctionOrderRepository.findByAuctionId(auctionId)
+			.map(this::from);
+	}
 
-    public void completeOrder(Long auctionId) {
-        AuctionOrder order = auctionOrderRepository.findByAuctionIdForUpdate(auctionId)
-                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
-        order.complete();
-    }
+	public void completeOrder(Long auctionId) {
+		AuctionOrder order = auctionOrderRepository.findByAuctionIdForUpdate(auctionId)
+			.orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
+		order.complete();
+	}
 
-    public void failOrder(Long auctionId) {
-        AuctionOrder order = auctionOrderRepository.findByAuctionIdForUpdate(auctionId)
-                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
-        order.fail();
-    }
+	public void failOrder(Long auctionId) {
+		AuctionOrder order = auctionOrderRepository.findByAuctionIdForUpdate(auctionId)
+			.orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
+		order.fail();
+	}
 
-    public AuctionOrderDto refundOrderWithLock(Long auctionId) {
-        AuctionOrder order = auctionOrderRepository.findByAuctionIdForUpdate(auctionId)
-                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
+	public AuctionOrderDto refundOrderWithLock(Long auctionId) {
+		AuctionOrder order = auctionOrderRepository.findByAuctionIdForUpdate(auctionId)
+			.orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
 
-        order.refund(); // 내부에서 SUCCESS 검증 및 FAILED 변경 수행
-        return from(order);
-    }
+		order.refund(); // 내부에서 SUCCESS 검증 및 FAILED 변경 수행
+		return from(order);
+	}
 
-    public Slice<AuctionOrderDto> findTimeoutOrders(LocalDateTime deadline, Pageable pageable) {
-        return auctionOrderRepository.findByStatusAndCreatedAtBefore(AuctionOrderStatus.PROCESSING, deadline, pageable)
-                .map(this::from);
-    }
+	public Slice<AuctionOrderDto> findTimeoutOrders(LocalDateTime deadline, Pageable pageable) {
+		return auctionOrderRepository.findByStatusAndCreatedAtBefore(AuctionOrderStatus.PROCESSING, deadline, pageable)
+			.map(this::from);
+	}
 
-    private AuctionOrderDto from(AuctionOrder order) {
-        return new AuctionOrderDto(
-                order.getId(),
-                order.getAuctionId(),
-                order.getSellerId(),
-                order.getBidderId(),
-                order.getFinalPrice(),
-                order.getStatus().name(),
-                order.getCreatedAt());
-    }
+	public Slice<AuctionOrderDto> findExpiringSoonOrders(LocalDateTime targetEndedAt, Pageable pageable) {
+		return auctionOrderRepository.findByStatusAndNoticedAtIsNullAndCreatedAtBefore(
+				AuctionOrderStatus.PROCESSING,
+				targetEndedAt,
+				pageable
+			)
+			.map(this::from);
+
+	}
+
+	@Transactional
+	public void markAsNoticed(Long orderId) {
+		AuctionOrder order = auctionOrderRepository.findById(orderId)
+			.orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
+		order.markAsNoticed();
+	}
+
+	private AuctionOrderDto from(AuctionOrder order) {
+		return new AuctionOrderDto(
+			order.getId(),
+			order.getAuctionId(),
+			order.getSellerId(),
+			order.getBidderId(),
+			order.getFinalPrice(),
+			order.getStatus().name(),
+			order.getCreatedAt());
+	}
 }

--- a/auction-service/src/main/java/com/bugzero/rarego/domain/AuctionOrder.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/domain/AuctionOrder.java
@@ -1,5 +1,7 @@
 package com.bugzero.rarego.domain;
 
+import java.time.LocalDateTime;
+
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.jpa.entity.BaseIdAndTime;
 import com.bugzero.rarego.global.response.ErrorType;
@@ -36,6 +38,8 @@ public class AuctionOrder extends BaseIdAndTime {
 	@Column(nullable = false)
 	private AuctionOrderStatus status;
 
+	private LocalDateTime noticedAt;
+
 	@Builder
 	public AuctionOrder(Long auctionId, Long sellerId, Long bidderId, Integer finalPrice) {
 		this.auctionId = auctionId;
@@ -65,5 +69,9 @@ public class AuctionOrder extends BaseIdAndTime {
 			throw new CustomException(ErrorType.INVALID_ORDER_STATUS);
 		}
 		this.status = AuctionOrderStatus.FAILED;
+	}
+
+	public void markAsNoticed() {
+		this.noticedAt = LocalDateTime.now();
 	}
 }

--- a/auction-service/src/main/java/com/bugzero/rarego/in/InternalAuctionController.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/in/InternalAuctionController.java
@@ -7,24 +7,33 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.bugzero.rarego.app.AuctionFacade;
 import com.bugzero.rarego.app.AuctionOrderService;
 import com.bugzero.rarego.app.AuctionSettleAuctionFacade;
-import com.bugzero.rarego.in.dto.AuctionAutoSettleResponseDto;
 import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
 import com.bugzero.rarego.global.response.SuccessResponseDto;
 import com.bugzero.rarego.global.response.SuccessType;
-import com.bugzero.rarego.global.response.ErrorType;
+import com.bugzero.rarego.in.dto.AuctionAutoSettleResponseDto;
 import com.bugzero.rarego.shared.auction.dto.AuctionOrderDto;
 import com.bugzero.rarego.shared.product.dto.ProductAuctionRequestDto;
 import com.bugzero.rarego.shared.product.dto.ProductAuctionUpdateDto;
+
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/v1/internal/auctions")
@@ -33,104 +42,132 @@ import org.springframework.web.bind.annotation.*;
 @Hidden
 public class InternalAuctionController {
 
-    private final AuctionSettleAuctionFacade facade;
-    private final AuctionFacade auctionFacade;
-    private final AuctionOrderService auctionOrderService;
+	private final AuctionSettleAuctionFacade facade;
+	private final AuctionFacade auctionFacade;
+	private final AuctionOrderService auctionOrderService;
 
-    @Operation(summary = "경매 정산", description = "종료된 경매를 정산합니다")
-    @PostMapping("/settle")
-    public SuccessResponseDto<AuctionAutoSettleResponseDto> settle() {
-        return SuccessResponseDto.from(SuccessType.OK, facade.settle());
-    }
+	@Operation(summary = "경매 정산", description = "종료된 경매를 정산합니다")
+	@PostMapping("/settle")
+	public SuccessResponseDto<AuctionAutoSettleResponseDto> settle() {
+		return SuccessResponseDto.from(SuccessType.OK, facade.settle());
+	}
 
-    @Operation(summary = "진행 중인 입찰이 있는지 확인", description = "진행 중인 입찰이 있는지 확인합니다")
-    @GetMapping("/members/{publicId}/bids/active")
-    public SuccessResponseDto<Boolean> hasActiveBids(@PathVariable String publicId) {
-        return SuccessResponseDto.from(SuccessType.OK, auctionFacade.hasActiveBids(publicId));
-    }
+	@Operation(summary = "진행 중인 입찰이 있는지 확인", description = "진행 중인 입찰이 있는지 확인합니다")
+	@GetMapping("/members/{publicId}/bids/active")
+	public SuccessResponseDto<Boolean> hasActiveBids(@PathVariable String publicId) {
+		return SuccessResponseDto.from(SuccessType.OK, auctionFacade.hasActiveBids(publicId));
+	}
 
-    @Operation(summary = "진행 중인 판매가 있는지 확인", description = "진행 중인 판매가 있는지 확인합니다")
-    @GetMapping("/members/{publicId}/sales/active")
-    public SuccessResponseDto<Boolean> hasActiveSales(@PathVariable String publicId) {
-        return SuccessResponseDto.from(SuccessType.OK, auctionFacade.hasActiveSales(publicId));
-    }
+	@Operation(summary = "진행 중인 판매가 있는지 확인", description = "진행 중인 판매가 있는지 확인합니다")
+	@GetMapping("/members/{publicId}/sales/active")
+	public SuccessResponseDto<Boolean> hasActiveSales(@PathVariable String publicId) {
+		return SuccessResponseDto.from(SuccessType.OK, auctionFacade.hasActiveSales(publicId));
+	}
 
-    @GetMapping("/members/{publicId}/orders/processing")
-    public SuccessResponseDto<Boolean> hasProcessingOrders(@PathVariable String publicId) {
-        return SuccessResponseDto.from(SuccessType.OK, auctionFacade.hasProcessingOrders(publicId));
-    }
+	@GetMapping("/members/{publicId}/orders/processing")
+	public SuccessResponseDto<Boolean> hasProcessingOrders(@PathVariable String publicId) {
+		return SuccessResponseDto.from(SuccessType.OK, auctionFacade.hasProcessingOrders(publicId));
+	}
 
-    @Operation(summary = "경매 주문 조회", description = "auctionId 기준 주문 정보를 조회합니다.")
-    @GetMapping("/orders/{auctionId}")
-    public SuccessResponseDto<AuctionOrderDto> getOrder(@PathVariable Long auctionId) {
-        AuctionOrderDto order = auctionOrderService.findByAuctionId(auctionId)
-                .orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
-        return SuccessResponseDto.from(SuccessType.OK, order);
-    }
+	@Operation(summary = "경매 주문 조회", description = "auctionId 기준 주문 정보를 조회합니다.")
+	@GetMapping("/orders/{auctionId}")
+	public SuccessResponseDto<AuctionOrderDto> getOrder(@PathVariable Long auctionId) {
+		AuctionOrderDto order = auctionOrderService.findByAuctionId(auctionId)
+			.orElseThrow(() -> new CustomException(ErrorType.AUCTION_ORDER_NOT_FOUND));
+		return SuccessResponseDto.from(SuccessType.OK, order);
+	}
 
-    @Operation(summary = "경매 주문 완료 처리", description = "auctionId 기준 주문을 완료 처리합니다.")
-    @PostMapping("/orders/{auctionId}/complete")
-    public SuccessResponseDto<Void> completeOrder(@PathVariable Long auctionId) {
-        auctionOrderService.completeOrder(auctionId);
-        return SuccessResponseDto.from(SuccessType.OK);
-    }
+	@Operation(summary = "경매 주문 완료 처리", description = "auctionId 기준 주문을 완료 처리합니다.")
+	@PostMapping("/orders/{auctionId}/complete")
+	public SuccessResponseDto<Void> completeOrder(@PathVariable Long auctionId) {
+		auctionOrderService.completeOrder(auctionId);
+		return SuccessResponseDto.from(SuccessType.OK);
+	}
 
-    @Operation(summary = "경매 주문 실패 처리", description = "auctionId 기준 주문을 실패 처리합니다.")
-    @PostMapping("/orders/{auctionId}/fail")
-    public SuccessResponseDto<Void> failOrder(@PathVariable Long auctionId) {
-        auctionOrderService.failOrder(auctionId);
-        return SuccessResponseDto.from(SuccessType.OK);
-    }
+	@Operation(summary = "경매 주문 실패 처리", description = "auctionId 기준 주문을 실패 처리합니다.")
+	@PostMapping("/orders/{auctionId}/fail")
+	public SuccessResponseDto<Void> failOrder(@PathVariable Long auctionId) {
+		auctionOrderService.failOrder(auctionId);
+		return SuccessResponseDto.from(SuccessType.OK);
+	}
 
-    @Operation(summary = "경매 주문 환불 처리", description = "auctionId 기준 주문을 환불 처리합니다.")
-    @PostMapping("/orders/{auctionId}/refund")
-    public SuccessResponseDto<AuctionOrderDto> refundOrder(@PathVariable Long auctionId) {
-        AuctionOrderDto order = auctionOrderService.refundOrderWithLock(auctionId);
-        return SuccessResponseDto.from(SuccessType.OK, order);
-    }
+	@Operation(summary = "경매 주문 환불 처리", description = "auctionId 기준 주문을 환불 처리합니다.")
+	@PostMapping("/orders/{auctionId}/refund")
+	public SuccessResponseDto<AuctionOrderDto> refundOrder(@PathVariable Long auctionId) {
+		AuctionOrderDto order = auctionOrderService.refundOrderWithLock(auctionId);
+		return SuccessResponseDto.from(SuccessType.OK, order);
+	}
 
-    @Operation(summary = "결제 타임아웃 주문 조회", description = "deadline 이전 생성된 PROCESSING 주문을 조회합니다.")
-    @GetMapping("/orders/timeout")
-    public ResponseEntity<SuccessResponseDto<List<AuctionOrderDto>>> findTimeoutOrders(
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime deadline,
-        @RequestParam int page,
-        @RequestParam int size
-    ) {
-        Slice<AuctionOrderDto> slice = auctionOrderService.findTimeoutOrders(deadline, PageRequest.of(page, size));
-        return ResponseEntity.ok()
-            .header("X-Has-Next", Boolean.toString(slice.hasNext()))
-            .body(SuccessResponseDto.from(SuccessType.OK, slice.getContent()));
-    }
+	@Operation(summary = "결제 타임아웃 주문 조회", description = "deadline 이전 생성된 PROCESSING 주문을 조회합니다.")
+	@GetMapping("/orders/timeout")
+	public ResponseEntity<SuccessResponseDto<List<AuctionOrderDto>>> findTimeoutOrders(
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime deadline,
+		@RequestParam int page,
+		@RequestParam int size
+	) {
+		Slice<AuctionOrderDto> slice = auctionOrderService.findTimeoutOrders(deadline, PageRequest.of(page, size));
+		return ResponseEntity.ok()
+			.header("X-Has-Next", Boolean.toString(slice.hasNext()))
+			.body(SuccessResponseDto.from(SuccessType.OK, slice.getContent()));
+	}
 
-    @Operation(summary = "경매정보 생성", description = "신규 상품 경매 정보를 생성합니다.")
-    @PostMapping("/{productId}/{publicId}")
-    public SuccessResponseDto<Long> createAuction(
-            @PathVariable Long productId,
-            @PathVariable String publicId,
-            @Valid @RequestBody ProductAuctionRequestDto productAuctionRequestDto
-    ) {
-        return SuccessResponseDto.from(SuccessType.CREATED,
-                auctionFacade.createAuction(productId, publicId, productAuctionRequestDto));
-    }
+	@Operation(summary = "결제 마감 임박 주문 조회", description = "targetEndedAt 이전 종료된 PROCESSING 주문 중 알림 미발송 건을 조회합니다.")
+	@GetMapping("/orders/expiring-soon")
+	public ResponseEntity<SuccessResponseDto<List<AuctionOrderDto>>> findExpiringSoonOrders(
+		@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime targetEndedAt,
+		@RequestParam int page,
+		@RequestParam int size
+	) {
+		// Service 호출 (Slice 반환)
+		Slice<AuctionOrderDto> slice = auctionOrderService.findExpiringSoonOrders(
+			targetEndedAt,
+			PageRequest.of(page, size)
+		);
 
-    @Operation(summary = "경매정보 수정", description = "검수 확정 전인 경매 정보를 수정합니다.")
-    @PatchMapping("/{publicId}")
-    public SuccessResponseDto<Long> updateAuction(
-            @PathVariable String publicId,
-            @Valid @RequestBody ProductAuctionUpdateDto productAuctionUpdateDto
-    ) {
-        return SuccessResponseDto.from(SuccessType.OK,
-                auctionFacade.updateAuction(publicId, productAuctionUpdateDto));
-    }
+		return ResponseEntity.ok()
+			// Client(스케줄러)가 다음 페이지 여부를 알 수 있도록 헤더 추가
+			.header("X-Has-Next", Boolean.toString(slice.hasNext()))
+			.body(SuccessResponseDto.from(SuccessType.OK, slice.getContent()));
+	}
 
-    @Operation(summary = "경매정보 삭제", description = "검수 확정 전인 경매 정보를 삭제합니다.")
-    @DeleteMapping("/{productId}/{publicId}")
-    public SuccessResponseDto<Void> deleteAuction(
-            @PathVariable String publicId,
-            @PathVariable Long productId
-    ) {
-        auctionFacade.deleteAuction(publicId, productId);
-        return SuccessResponseDto.from(SuccessType.OK);
-    }
+	@Operation(summary = "알림 발송 완료 처리", description = "주문의 알림 발송 시각(noticedAt)을 업데이트하여 중복 발송을 방지합니다.")
+	@PatchMapping("/orders/{orderId}/notice")
+	public ResponseEntity<Void> markAsNoticed(@PathVariable Long orderId) {
+		auctionOrderService.markAsNoticed(orderId);
+
+		// Body 없이 200 OK 반환 (Client의 toBodilessEntity()와 매칭)
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "경매정보 생성", description = "신규 상품 경매 정보를 생성합니다.")
+	@PostMapping("/{productId}/{publicId}")
+	public SuccessResponseDto<Long> createAuction(
+		@PathVariable Long productId,
+		@PathVariable String publicId,
+		@Valid @RequestBody ProductAuctionRequestDto productAuctionRequestDto
+	) {
+		return SuccessResponseDto.from(SuccessType.CREATED,
+			auctionFacade.createAuction(productId, publicId, productAuctionRequestDto));
+	}
+
+	@Operation(summary = "경매정보 수정", description = "검수 확정 전인 경매 정보를 수정합니다.")
+	@PatchMapping("/{publicId}")
+	public SuccessResponseDto<Long> updateAuction(
+		@PathVariable String publicId,
+		@Valid @RequestBody ProductAuctionUpdateDto productAuctionUpdateDto
+	) {
+		return SuccessResponseDto.from(SuccessType.OK,
+			auctionFacade.updateAuction(publicId, productAuctionUpdateDto));
+	}
+
+	@Operation(summary = "경매정보 삭제", description = "검수 확정 전인 경매 정보를 삭제합니다.")
+	@DeleteMapping("/{productId}/{publicId}")
+	public SuccessResponseDto<Void> deleteAuction(
+		@PathVariable String publicId,
+		@PathVariable Long productId
+	) {
+		auctionFacade.deleteAuction(publicId, productId);
+		return SuccessResponseDto.from(SuccessType.OK);
+	}
 }
 

--- a/auction-service/src/main/java/com/bugzero/rarego/in/InternalAuctionController.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/in/InternalAuctionController.java
@@ -118,14 +118,12 @@ public class InternalAuctionController {
 		@RequestParam int page,
 		@RequestParam int size
 	) {
-		// Service 호출 (Slice 반환)
 		Slice<AuctionOrderDto> slice = auctionOrderService.findExpiringSoonOrders(
 			targetEndedAt,
 			PageRequest.of(page, size)
 		);
 
 		return ResponseEntity.ok()
-			// Client(스케줄러)가 다음 페이지 여부를 알 수 있도록 헤더 추가
 			.header("X-Has-Next", Boolean.toString(slice.hasNext()))
 			.body(SuccessResponseDto.from(SuccessType.OK, slice.getContent()));
 	}
@@ -135,7 +133,6 @@ public class InternalAuctionController {
 	public ResponseEntity<Void> markAsNoticed(@PathVariable Long orderId) {
 		auctionOrderService.markAsNoticed(orderId);
 
-		// Body 없이 200 OK 반환 (Client의 toBodilessEntity()와 매칭)
 		return ResponseEntity.ok().build();
 	}
 

--- a/auction-service/src/main/java/com/bugzero/rarego/out/AuctionOrderRepository.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/out/AuctionOrderRepository.java
@@ -1,8 +1,10 @@
 package com.bugzero.rarego.out;
 
-import com.bugzero.rarego.domain.AuctionOrder;
-import com.bugzero.rarego.domain.AuctionOrderStatus;
-import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -11,55 +13,58 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import com.bugzero.rarego.domain.AuctionOrder;
+import com.bugzero.rarego.domain.AuctionOrderStatus;
+
+import jakarta.persistence.LockModeType;
 
 public interface AuctionOrderRepository extends JpaRepository<AuctionOrder, Long> {
 
-    Optional<AuctionOrder> findByAuctionId(Long auctionId);
+	Optional<AuctionOrder> findByAuctionId(Long auctionId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT o FROM AuctionOrder o WHERE o.auctionId = :auctionId")
-    Optional<AuctionOrder> findByAuctionIdForUpdate(@Param("auctionId") Long auctionId);
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT o FROM AuctionOrder o WHERE o.auctionId = :auctionId")
+	Optional<AuctionOrder> findByAuctionIdForUpdate(@Param("auctionId") Long auctionId);
 
-    // 경매 ID 목록으로 주문 정보 조회
-    List<AuctionOrder> findAllByAuctionIdIn(Collection<Long> auctionIds);
+	// 경매 ID 목록으로 주문 정보 조회
+	List<AuctionOrder> findAllByAuctionIdIn(Collection<Long> auctionIds);
 
-    // 타임아웃 대상 주문 조회 (PROCESSING 상태 + 생성일 기준)
-    Slice<AuctionOrder> findByStatusAndCreatedAtBefore(AuctionOrderStatus status, LocalDateTime deadline,
-                                                       Pageable pageable);
+	// 타임아웃 대상 주문 조회 (PROCESSING 상태 + 생성일 기준)
+	Slice<AuctionOrder> findByStatusAndCreatedAtBefore(AuctionOrderStatus status, LocalDateTime deadline,
+		Pageable pageable);
 
-    // status가 NULL이면 무시(=전체 조회), 값이 있으면 일치하는 것만 조회
-    @Query("SELECT ao FROM AuctionOrder ao WHERE ao.bidderId = :bidderId AND (:status IS NULL OR ao.status = :status)")
-    Page<AuctionOrder> findAllByBidderIdAndStatus(
-            @Param("bidderId") Long bidderId,
-            @Param("status") AuctionOrderStatus status,
-            Pageable pageable
-    );
+	Slice<AuctionOrder> findByStatusAndNoticedAtIsNullAndCreatedAtBefore(AuctionOrderStatus status,
+		LocalDateTime targetEndedAt, Pageable pageable);
 
-    @Query("""
-                SELECT CASE WHEN COUNT(o) > 0 THEN true ELSE false END
-                FROM AuctionOrder o
-                JOIN AuctionMember m ON o.bidderId = m.id
-                WHERE m.publicId = :publicId
-                AND o.status = :status
-            """)
-    boolean existsByBuyerPublicIdAndStatus(
-            @Param("publicId") String publicId,
-            @Param("status") AuctionOrderStatus status
-    );
+	// status가 NULL이면 무시(=전체 조회), 값이 있으면 일치하는 것만 조회
+	@Query("SELECT ao FROM AuctionOrder ao WHERE ao.bidderId = :bidderId AND (:status IS NULL OR ao.status = :status)")
+	Page<AuctionOrder> findAllByBidderIdAndStatus(
+		@Param("bidderId") Long bidderId,
+		@Param("status") AuctionOrderStatus status,
+		Pageable pageable
+	);
 
-    @Query("""
-                SELECT CASE WHEN COUNT(o) > 0 THEN true ELSE false END
-                FROM AuctionOrder o
-                JOIN AuctionMember m ON o.sellerId = m.id
-                WHERE m.publicId = :publicId
-                AND o.status = :status
-            """)
-    boolean existsBySellerPublicIdAndStatus(
-            @Param("publicId") String publicId,
-            @Param("status") AuctionOrderStatus status
-    );
+	@Query("""
+		    SELECT CASE WHEN COUNT(o) > 0 THEN true ELSE false END
+		    FROM AuctionOrder o
+		    JOIN AuctionMember m ON o.bidderId = m.id
+		    WHERE m.publicId = :publicId
+		    AND o.status = :status
+		""")
+	boolean existsByBuyerPublicIdAndStatus(
+		@Param("publicId") String publicId,
+		@Param("status") AuctionOrderStatus status
+	);
+
+	@Query("""
+		    SELECT CASE WHEN COUNT(o) > 0 THEN true ELSE false END
+		    FROM AuctionOrder o
+		    JOIN AuctionMember m ON o.sellerId = m.id
+		    WHERE m.publicId = :publicId
+		    AND o.status = :status
+		""")
+	boolean existsBySellerPublicIdAndStatus(
+		@Param("publicId") String publicId,
+		@Param("status") AuctionOrderStatus status
+	);
 }

--- a/auction-service/src/test/java/com/bugzero/rarego/in/InternalAuctionControllerTest.java
+++ b/auction-service/src/test/java/com/bugzero/rarego/in/InternalAuctionControllerTest.java
@@ -16,6 +16,9 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,9 +26,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.bugzero.rarego.app.AuctionFacade;
 import com.bugzero.rarego.app.AuctionOrderService;
 import com.bugzero.rarego.app.AuctionSettleAuctionFacade;
-import com.bugzero.rarego.in.dto.AuctionAutoSettleResponseDto;
 import com.bugzero.rarego.global.aspect.ResponseAspect;
 import com.bugzero.rarego.global.response.SuccessType;
+import com.bugzero.rarego.in.dto.AuctionAutoSettleResponseDto;
+import com.bugzero.rarego.shared.auction.dto.AuctionOrderDto;
 import com.bugzero.rarego.shared.product.dto.ProductAuctionRequestDto;
 import com.bugzero.rarego.shared.product.dto.ProductAuctionUpdateDto;
 
@@ -37,180 +41,241 @@ import tools.jackson.databind.ObjectMapper;
 @AutoConfigureMockMvc(addFilters = false)
 class InternalAuctionControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @MockitoBean
-    private AuctionSettleAuctionFacade facade;
+	@MockitoBean
+	private AuctionSettleAuctionFacade facade;
 
-    @MockitoBean
-    private AuctionFacade auctionFacade;
+	@MockitoBean
+	private AuctionFacade auctionFacade;
 
-    @MockitoBean
-    private AuctionOrderService auctionOrderService;
+	@MockitoBean
+	private AuctionOrderService auctionOrderService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+	@Autowired
+	private ObjectMapper objectMapper;
 
-    @Nested
-    @DisplayName("경매 정산 API")
-    class SettleTests {
+	@Nested
+	@DisplayName("경매 정산 API")
+	class SettleTests {
 
-        @Test
-        @DisplayName("경매 자동 낙찰 처리 API 호출 성공")
-        void settle_Success() throws Exception {
-            // given
-            AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
-                    .requestTime(LocalDateTime.now())
-                    .processedCount(10)
-                    .successCount(8)
-                    .failCount(2)
-                    .details(List.of())
-                    .build();
+		@Test
+		@DisplayName("경매 자동 낙찰 처리 API 호출 성공")
+		void settle_Success() throws Exception {
+			// given
+			AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
+				.requestTime(LocalDateTime.now())
+				.processedCount(10)
+				.successCount(8)
+				.failCount(2)
+				.details(List.of())
+				.build();
 
-            given(facade.settle()).willReturn(mockResponse);
+			given(facade.settle()).willReturn(mockResponse);
 
-            // when & then
-            mockMvc.perform(post("/api/v1/internal/auctions/settle"))
-                    .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
-                    .andExpect(jsonPath("$.message").value(SuccessType.OK.getMessage()))
-                    .andExpect(jsonPath("$.data.processedCount").value(10))
-                    .andExpect(jsonPath("$.data.successCount").value(8))
-                    .andExpect(jsonPath("$.data.failCount").value(2));
+			// when & then
+			mockMvc.perform(post("/api/v1/internal/auctions/settle"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.status").value(SuccessType.OK.getHttpStatus()))
+				.andExpect(jsonPath("$.message").value(SuccessType.OK.getMessage()))
+				.andExpect(jsonPath("$.data.processedCount").value(10))
+				.andExpect(jsonPath("$.data.successCount").value(8))
+				.andExpect(jsonPath("$.data.failCount").value(2));
 
-            verify(facade, times(1)).settle();
-        }
+			verify(facade, times(1)).settle();
+		}
 
-        @Test
-        @DisplayName("처리할 경매가 없는 경우")
-        void settle_NoAuctions() throws Exception {
-            // given
-            AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
-                    .requestTime(LocalDateTime.now())
-                    .processedCount(0)
-                    .successCount(0)
-                    .failCount(0)
-                    .details(List.of())
-                    .build();
+		@Test
+		@DisplayName("처리할 경매가 없는 경우")
+		void settle_NoAuctions() throws Exception {
+			// given
+			AuctionAutoSettleResponseDto mockResponse = AuctionAutoSettleResponseDto.builder()
+				.requestTime(LocalDateTime.now())
+				.processedCount(0)
+				.successCount(0)
+				.failCount(0)
+				.details(List.of())
+				.build();
 
-            given(facade.settle()).willReturn(mockResponse);
+			given(facade.settle()).willReturn(mockResponse);
 
-            // when & then
-            mockMvc.perform(post("/api/v1/internal/auctions/settle"))
-                    .andDo(print())
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.processedCount").value(0));
+			// when & then
+			mockMvc.perform(post("/api/v1/internal/auctions/settle"))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.processedCount").value(0));
 
-            verify(facade, times(1)).settle();
-        }
-    }
+			verify(facade, times(1)).settle();
+		}
+	}
 
-    @Nested
-    @DisplayName("경매정보 API")
-    class InfoTests {
-        @Test
-        @DisplayName("정상적인 경매 생성 요청 시 201 OK와 생성된 ID를 반환한다")
-        void createAuction_Success() throws Exception {
-            // given
-            Long productId = 1L;
-            String publicId = "1L";
-            ProductAuctionRequestDto requestDto = ProductAuctionRequestDto.builder()
-                .startPrice(10000)
-                .durationDays(7)
-                .build();
+	@Nested
+	@DisplayName("경매정보 API")
+	class InfoTests {
+		@Test
+		@DisplayName("정상적인 경매 생성 요청 시 201 OK와 생성된 ID를 반환한다")
+		void createAuction_Success() throws Exception {
+			// given
+			Long productId = 1L;
+			String publicId = "1L";
+			ProductAuctionRequestDto requestDto = ProductAuctionRequestDto.builder()
+				.startPrice(10000)
+				.durationDays(7)
+				.build();
 
-            given(auctionFacade.createAuction(eq(productId), eq(publicId), any(ProductAuctionRequestDto.class)))
-                .willReturn(10L);
+			given(auctionFacade.createAuction(eq(productId), eq(publicId), any(ProductAuctionRequestDto.class)))
+				.willReturn(10L);
 
-            // when & then
-            mockMvc.perform(post("/api/v1/internal/auctions/{productId}/{publicId}", productId, publicId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data").value(10));
-        }
+			// when & then
+			mockMvc.perform(post("/api/v1/internal/auctions/{productId}/{publicId}", productId, publicId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(requestDto)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data").value(10));
+		}
 
-        @Test
-        @DisplayName("입찰 시작가가 100원 미만이면 400 Bad Request를 반환한다")
-        void createAuction_Fail_MinPrice() throws Exception {
-            // given
-            Long productId = 1L;
-            String sellerUUID = "1L";
+		@Test
+		@DisplayName("입찰 시작가가 100원 미만이면 400 Bad Request를 반환한다")
+		void createAuction_Fail_MinPrice() throws Exception {
+			// given
+			Long productId = 1L;
+			String sellerUUID = "1L";
 
-            ProductAuctionRequestDto invalidDto = ProductAuctionRequestDto.builder()
-                .startPrice(50) // @Min(100) 위반
-                .durationDays(7)
-                .build();
+			ProductAuctionRequestDto invalidDto = ProductAuctionRequestDto.builder()
+				.startPrice(50) // @Min(100) 위반
+				.durationDays(7)
+				.build();
 
-            // when & then
-            mockMvc.perform(post("/api/v1/internal/auctions/{productId}/{publicId}", productId, sellerUUID)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(invalidDto)))
-                .andExpect(status().isBadRequest());
-        }
+			// when & then
+			mockMvc.perform(post("/api/v1/internal/auctions/{productId}/{publicId}", productId, sellerUUID)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(invalidDto)))
+				.andExpect(status().isBadRequest());
+		}
 
-        @Test
-        @DisplayName("경매기간 설정을 범위 내 하지 않으면 400 Bad Request를 반환한다")
-        void createAuction_Fail_MinDuration() throws Exception {
-            // given
-            Long productId = 1L;
-            String sellerUUID = "1L";
+		@Test
+		@DisplayName("경매기간 설정을 범위 내 하지 않으면 400 Bad Request를 반환한다")
+		void createAuction_Fail_MinDuration() throws Exception {
+			// given
+			Long productId = 1L;
+			String sellerUUID = "1L";
 
-            ProductAuctionRequestDto invalidDto = ProductAuctionRequestDto.builder()
-                .startPrice(10000) // @Min(100) 위반
-                .durationDays(100)
-                .build();
+			ProductAuctionRequestDto invalidDto = ProductAuctionRequestDto.builder()
+				.startPrice(10000) // @Min(100) 위반
+				.durationDays(100)
+				.build();
 
-            // when & then
-            mockMvc.perform(post("/api/v1/internal/auctions/{productId}/{publicId}", productId, sellerUUID)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(invalidDto)))
-                .andExpect(status().isBadRequest());
-        }
+			// when & then
+			mockMvc.perform(post("/api/v1/internal/auctions/{productId}/{publicId}", productId, sellerUUID)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(invalidDto)))
+				.andExpect(status().isBadRequest());
+		}
 
-        @Test
-        @DisplayName("정상적인 경매 수정 요청 시 200 OK와 생성된 ID를 반환한다")
-        void updateAuction_Success() throws Exception {
-            // given
-            String publicId = "1L";
-            ProductAuctionUpdateDto updateDto = ProductAuctionUpdateDto.builder()
-                .auctionId(1L)
-                .startPrice(10000)
-                .durationDays(7)
-                .build();
+		@Test
+		@DisplayName("정상적인 경매 수정 요청 시 200 OK와 생성된 ID를 반환한다")
+		void updateAuction_Success() throws Exception {
+			// given
+			String publicId = "1L";
+			ProductAuctionUpdateDto updateDto = ProductAuctionUpdateDto.builder()
+				.auctionId(1L)
+				.startPrice(10000)
+				.durationDays(7)
+				.build();
 
-            given(auctionFacade.updateAuction(eq(publicId), any(ProductAuctionUpdateDto.class)))
-                .willReturn(10L);
+			given(auctionFacade.updateAuction(eq(publicId), any(ProductAuctionUpdateDto.class)))
+				.willReturn(10L);
 
-            // when & then
-            mockMvc.perform(patch("/api/v1/internal/auctions/{publicId}", publicId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(updateDto)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").value(10));
-        }
+			// when & then
+			mockMvc.perform(patch("/api/v1/internal/auctions/{publicId}", publicId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(updateDto)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data").value(10));
+		}
 
-        @Test
-        @DisplayName("성공 - 경매 삭제 요청 시 200 OK를 반환한다")
-        void deleteAuction_Success() throws Exception {
-            // given
-            String publicId = "seller-uuid";
-            Long productId = 100L;
+		@Test
+		@DisplayName("성공 - 경매 삭제 요청 시 200 OK를 반환한다")
+		void deleteAuction_Success() throws Exception {
+			// given
+			String publicId = "seller-uuid";
+			Long productId = 100L;
 
-            // void 메서드이므로 doNothing 설정
-            doNothing().when(auctionFacade).deleteAuction(eq(publicId), eq(productId));
+			// void 메서드이므로 doNothing 설정
+			doNothing().when(auctionFacade).deleteAuction(eq(publicId), eq(productId));
 
-            // when & then
-            mockMvc.perform(delete("/api/v1/internal/auctions/{productId}/{publicId}", productId, publicId)
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(200))
-                .andDo(print());
+			// when & then
+			mockMvc.perform(delete("/api/v1/internal/auctions/{productId}/{publicId}", productId, publicId)
+					.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.status").value(200))
+				.andDo(print());
 
-            // UseCase 호출 여부 최종 확인
-            verify(auctionFacade).deleteAuction(eq(publicId), eq(productId));
-        }
-    }
+			// UseCase 호출 여부 최종 확인
+			verify(auctionFacade).deleteAuction(eq(publicId), eq(productId));
+		}
+	}
+
+	@Test
+	@DisplayName("성공 - 결제 마감 임박 주문 목록을 조회하면 헤더에 hasNext를 포함하여 반환한다")
+	void findExpiringSoonOrders_Success() throws Exception {
+		// given
+		LocalDateTime targetEndedAt = LocalDateTime.of(2026, 2, 7, 10, 0, 0);
+		String targetEndedAtStr = targetEndedAt.toString(); // ISO DateTime String
+
+		AuctionOrderDto orderDto = new AuctionOrderDto(
+			1L,
+			100L,
+			200L,
+			300L,
+			50000,
+			"PROCESSING",
+			LocalDateTime.now()
+		);
+
+		// Slice Mock 생성 (hasNext = true 상황 가정)
+		Slice<AuctionOrderDto> mockSlice = new SliceImpl<>(List.of(orderDto), PageRequest.of(0, 10), true);
+
+		given(auctionOrderService.findExpiringSoonOrders(eq(targetEndedAt), any(PageRequest.class)))
+			.willReturn(mockSlice);
+
+		// when & then
+		mockMvc.perform(get("/api/v1/internal/auctions/orders/expiring-soon")
+				.param("targetEndedAt", targetEndedAtStr)
+				.param("page", "0")
+				.param("size", "10")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			// 1. 헤더 검증 (X-Has-Next)
+			.andExpect(header().string("X-Has-Next", "true"))
+			// 2. 응답 바디 검증
+			.andExpect(jsonPath("$.status").value(200))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data[0].orderId").value(1L));
+
+		// Service 호출 검증
+		verify(auctionOrderService).findExpiringSoonOrders(eq(targetEndedAt), any(PageRequest.class));
+	}
+
+	@Test
+	@DisplayName("성공 - 주문 알림 발송 상태를 업데이트(PATCH)한다")
+	void markAsNoticed_Success() throws Exception {
+		// given
+		Long orderId = 123L;
+
+		// void 메서드이므로 doNothing
+		doNothing().when(auctionOrderService).markAsNoticed(orderId);
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/internal/auctions/orders/{orderId}/notice", orderId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk()); // 200 OK
+
+		// Service 호출 검증
+		verify(auctionOrderService).markAsNoticed(orderId);
+	}
 }

--- a/common/src/main/java/com/bugzero/rarego/shared/payment/event/AuctionPaymentExpiringSoonEvent.java
+++ b/common/src/main/java/com/bugzero/rarego/shared/payment/event/AuctionPaymentExpiringSoonEvent.java
@@ -1,0 +1,13 @@
+package com.bugzero.rarego.shared.payment.event;
+
+import java.time.LocalDateTime;
+
+public record AuctionPaymentExpiringSoonEvent(
+	Long orderId,
+	Long auctionId,
+	Long buyerId,
+	Long sellerId,
+	int amount,
+	LocalDateTime expiredAt
+) {
+}

--- a/payment-service/src/main/java/com/bugzero/rarego/app/PaymentAuctionExpiringSoonUseCase.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/app/PaymentAuctionExpiringSoonUseCase.java
@@ -1,0 +1,32 @@
+package com.bugzero.rarego.app;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bugzero.rarego.global.event.EventPublisher;
+import com.bugzero.rarego.shared.auction.dto.AuctionOrderDto;
+import com.bugzero.rarego.shared.payment.event.AuctionPaymentExpiringSoonEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentAuctionExpiringSoonUseCase {
+	private final EventPublisher eventPublisher;
+
+	@Transactional
+	public void publishExpiringSoonEvent(AuctionOrderDto order, LocalDateTime expiredAt) {
+		AuctionPaymentExpiringSoonEvent event = new AuctionPaymentExpiringSoonEvent(
+			order.orderId(),
+			order.auctionId(),
+			order.bidderId(),
+			order.sellerId(),
+			order.finalPrice(),
+			expiredAt
+		);
+
+		eventPublisher.publish(event);
+	}
+}

--- a/payment-service/src/main/java/com/bugzero/rarego/app/PaymentFacade.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/app/PaymentFacade.java
@@ -1,8 +1,15 @@
 package com.bugzero.rarego.app;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.bugzero.rarego.domain.PaymentMember;
 import com.bugzero.rarego.domain.SettlementStatus;
 import com.bugzero.rarego.domain.WalletTransactionType;
+import com.bugzero.rarego.global.response.PagedResponseDto;
 import com.bugzero.rarego.in.dto.AuctionFinalPaymentRequestDto;
 import com.bugzero.rarego.in.dto.AuctionFinalPaymentResponseDto;
 import com.bugzero.rarego.in.dto.PaymentConfirmRequestDto;
@@ -10,20 +17,15 @@ import com.bugzero.rarego.in.dto.PaymentConfirmResponseDto;
 import com.bugzero.rarego.in.dto.PaymentRequestDto;
 import com.bugzero.rarego.in.dto.PaymentRequestResponseDto;
 import com.bugzero.rarego.in.dto.RefundResponseDto;
-import com.bugzero.rarego.shared.payment.dto.SettlementResponseDto;
 import com.bugzero.rarego.in.dto.WalletResponseDto;
 import com.bugzero.rarego.in.dto.WalletTransactionResponseDto;
-import com.bugzero.rarego.global.response.PagedResponseDto;
+import com.bugzero.rarego.shared.auction.dto.AuctionOrderDto;
 import com.bugzero.rarego.shared.member.domain.MemberDto;
 import com.bugzero.rarego.shared.payment.dto.DepositHoldRequestDto;
 import com.bugzero.rarego.shared.payment.dto.DepositHoldResponseDto;
+import com.bugzero.rarego.shared.payment.dto.SettlementResponseDto;
 
 import lombok.RequiredArgsConstructor;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +42,7 @@ public class PaymentFacade {
 	private final PaymentSyncMemberUseCase paymentSyncMemberUseCase;
 	private final PaymentGetMyWalletUseCase paymentGetMyWalletUseCase;
 	private final PaymentWithdrawUseCase paymentWithdrawUseCase;
+	private final PaymentAuctionExpiringSoonUseCase paymentAuctionExpiringSoonUseCase;
 
 	/**
 	 * 보증금 홀딩
@@ -127,5 +130,12 @@ public class PaymentFacade {
 	 */
 	public WalletResponseDto getMyWallet(String memberPublicId) {
 		return paymentGetMyWalletUseCase.getMyWallet(memberPublicId);
+	}
+
+	/**
+	 * 결제 마감 임박 이벤트 발행
+	 */
+	public void publishExpiringSoonEvent(AuctionOrderDto order, LocalDateTime expiredAt) {
+		paymentAuctionExpiringSoonUseCase.publishExpiringSoonEvent(order, expiredAt);
 	}
 }

--- a/payment-service/src/main/java/com/bugzero/rarego/in/PaymentExpiringSoonScheduler.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/in/PaymentExpiringSoonScheduler.java
@@ -1,0 +1,83 @@
+package com.bugzero.rarego.in;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.app.PaymentFacade;
+import com.bugzero.rarego.out.AuctionOrderApiClient;
+import com.bugzero.rarego.shared.auction.dto.AuctionOrderDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentExpiringSoonScheduler {
+	private static final int BATCH_SIZE = 100;
+
+	private final AuctionOrderApiClient auctionOrderApiClient;
+	private final PaymentFacade paymentFacade;
+
+	@Value("${auction.payment-timeout-days:3}")
+	private int paymentTimeoutDays;
+
+	/**
+	 * 매일 오전 10시에 실행
+	 * - 사용자가 깨어있는 시간에 알림을 보내 반응률을 높임
+	 * - 자정에 도는 타임아웃 배치와 DB 부하를 분산시킴
+	 */
+	@Scheduled(cron = "0 0 10 * * *", zone = "Asia/Seoul")
+	public void checkExpiringSoon() {
+		log.info("낙찰 결제 마감 임박 체크 시작");
+
+		LocalDateTime targetEndedAt = LocalDate.now().minusDays(paymentTimeoutDays).atTime(LocalTime.MAX);
+
+		int successCount = 0;
+		int failCount = 0;
+		int totalProcessed = 0;
+
+		while (true) {
+			AuctionOrderApiClient.AuctionOrderSlice orders = auctionOrderApiClient.findExpiringSoonOrders(
+				targetEndedAt,
+				PageRequest.of(0, BATCH_SIZE)
+			);
+
+			if (orders.content().isEmpty()) {
+				break;
+			}
+
+			for (AuctionOrderDto order : orders.content()) {
+				try {
+					LocalDateTime expiredAt = LocalDate.now().atTime(LocalTime.MAX);
+
+					// 결제 마감 임박 이벤트 발행
+					paymentFacade.publishExpiringSoonEvent(order, expiredAt);
+
+					// 이벤트 발행 완료 처리 (중복 발행 방지)
+					auctionOrderApiClient.markAsNoticed(order.orderId());
+
+					successCount++;
+					log.info("마감 임박 처리 완료: auctionId={}", order.auctionId());
+
+				} catch (Exception e) {
+					failCount++;
+					log.error("마감 임박 알림 실패: auctionId={}", order.auctionId(), e);
+				}
+				totalProcessed++;
+			}
+		}
+
+		if (totalProcessed == 0) {
+			log.info("마감 임박 알림 대상 없음");
+		} else {
+			log.info("결제 마감 임박 알림 완료: 총 {}건, 성공={}, 실패={}", totalProcessed, successCount, failCount);
+		}
+	}
+}

--- a/payment-service/src/main/java/com/bugzero/rarego/out/AuctionOrderApiClient.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/out/AuctionOrderApiClient.java
@@ -90,6 +90,37 @@ public class AuctionOrderApiClient {
 			.toEntity(new ParameterizedTypeReference<>() {
 			});
 
+		return getAuctionOrderSlice(entity);
+	}
+
+	public AuctionOrderSlice findExpiringSoonOrders(LocalDateTime targetEndedAt, Pageable pageable) {
+		ResponseEntity<SuccessResponseDto<List<AuctionOrderDto>>> entity = restClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/orders/expiring-soon")
+				.queryParam("targetEndedAt", targetEndedAt)
+				.queryParam("page", pageable.getPageNumber())
+				.queryParam("size", pageable.getPageSize())
+				.build())
+			.retrieve()
+			.onStatus(HttpStatusCode::isError, errorHandler::handle)
+			.toEntity(new ParameterizedTypeReference<>() {
+			});
+
+		return getAuctionOrderSlice(entity);
+	}
+
+	public void markAsNoticed(Long orderId) {
+		restClient.patch()
+			.uri(uriBuilder -> uriBuilder
+				.path("/orders/{orderId}/notice")
+				.build(orderId))
+			.retrieve()
+			.onStatus(HttpStatusCode::isError, errorHandler::handle)
+			.toBodilessEntity();
+	}
+
+	private AuctionOrderApiClient.AuctionOrderSlice getAuctionOrderSlice(
+		ResponseEntity<SuccessResponseDto<List<AuctionOrderDto>>> entity) {
 		SuccessResponseDto<List<AuctionOrderDto>> body = entity.getBody();
 		List<AuctionOrderDto> content = body == null || body.data() == null ? List.of() : body.data();
 		boolean hasNext = Boolean.parseBoolean(entity.getHeaders().getFirst(HAS_NEXT_HEADER));

--- a/payment-service/src/main/java/com/bugzero/rarego/out/PaymentEventKafkaBridge.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/out/PaymentEventKafkaBridge.java
@@ -3,11 +3,13 @@ package com.bugzero.rarego.out;
 import java.util.UUID;
 
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.bugzero.rarego.shared.payment.event.AuctionPaymentCompletedEvent;
+import com.bugzero.rarego.shared.payment.event.AuctionPaymentExpiringSoonEvent;
 import com.bugzero.rarego.shared.payment.event.SettlementFinishedEvent;
 
 import lombok.RequiredArgsConstructor;
@@ -21,27 +23,50 @@ public class PaymentEventKafkaBridge {
 
 	private static final String TOPIC_SETTLEMENT_FINISHED = "payment-settlement-finished";
 	private static final String TOPIC_AUCTION_PAYMENT_COMPLETED = "payment-auction-completed";
+	private static final String TOPIC_PAYMENT_EXPIRING_SOON = "payment-auction-expiring-soon";
 
+	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void send(SettlementFinishedEvent event) {
 		if (event.totalCount() == 0) {
 			return;
 		}
 
-		log.info("Kafka 발행: 정산 완료 ( 총 {} 건, 금액 {}원)", event.totalCount(), event.totalAmount());
-
-		String key = UUID.randomUUID().toString(); // 묶음 처리 건이므로 ID가 없으므로 UUID 이용
-
-		kafkaTemplate.send(TOPIC_SETTLEMENT_FINISHED, key, event);
+		try {
+			log.info("Kafka 발행 시작: 정산 완료 (총 {} 건)", event.totalCount());
+			String key = UUID.randomUUID().toString();
+			kafkaTemplate.send(TOPIC_SETTLEMENT_FINISHED, key, event);
+		} catch (Exception e) {
+			log.error("Kafka 발행 실패 (정산): totalCount={}", event.totalCount(), e);
+		}
 	}
 
+	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void send(AuctionPaymentCompletedEvent event) {
-		log.info("Kafka 발행: 낙찰 결제 완료 (orderId={}, auctionId={})", event.orderId(), event.auctionId());
+		try {
+			log.info("Kafka 발행 시작: 낙찰 결제 완료 (orderId={})", event.orderId());
 
-		// Key를 auctionId로 설정하여, 동일 경매 건에 대한 메시지 순서를 보장
-		String key = String.valueOf(event.auctionId());
+			// Key: auctionId (순서 보장)
+			String key = String.valueOf(event.auctionId());
+			kafkaTemplate.send(TOPIC_AUCTION_PAYMENT_COMPLETED, key, event);
 
-		kafkaTemplate.send(TOPIC_AUCTION_PAYMENT_COMPLETED, key, event);
+		} catch (Exception e) {
+			log.error("Kafka 발행 실패 (결제완료): orderId={}, auctionId={}", event.orderId(), event.auctionId(), e);
+		}
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void send(AuctionPaymentExpiringSoonEvent event) {
+		log.info("결제 마감 임박 이벤트 Kafka 발행 시작: orderId={}, auctionId={}", event.orderId(), event.auctionId());
+
+		try {
+			kafkaTemplate.send(TOPIC_PAYMENT_EXPIRING_SOON, String.valueOf(event.auctionId()), event);
+
+		} catch (Exception e) {
+			log.error("Kafka 메시지 발행 실패: orderId={}", event.auctionId(), e);
+			// 필요 시 여기서 재시도 로직이나 DLQ 처리 (혹은 스케줄러가 다음 턴에 다시 처리하도록 둠)
+		}
 	}
 }

--- a/payment-service/src/main/java/com/bugzero/rarego/out/PaymentEventKafkaBridge.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/out/PaymentEventKafkaBridge.java
@@ -27,8 +27,8 @@ public class PaymentEventKafkaBridge {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void send(SettlementFinishedEvent event) {
-		if (event.totalCount() == 0) {
+	public void sendSettlementFinished(SettlementFinishedEvent event) {
+		if (event.settlements().isEmpty()) {
 			return;
 		}
 
@@ -43,7 +43,7 @@ public class PaymentEventKafkaBridge {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void send(AuctionPaymentCompletedEvent event) {
+	public void sendAuctionPaymentCompleted(AuctionPaymentCompletedEvent event) {
 		try {
 			log.info("Kafka 발행 시작: 낙찰 결제 완료 (orderId={})", event.orderId());
 
@@ -58,7 +58,7 @@ public class PaymentEventKafkaBridge {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void send(AuctionPaymentExpiringSoonEvent event) {
+	public void sendAuctionPaymentExpiringSoon(AuctionPaymentExpiringSoonEvent event) {
 		log.info("결제 마감 임박 이벤트 Kafka 발행 시작: orderId={}, auctionId={}", event.orderId(), event.auctionId());
 
 		try {

--- a/payment-service/src/test/java/com/bugzero/rarego/in/PaymentExpiringSoonSchedulerTest.java
+++ b/payment-service/src/test/java/com/bugzero/rarego/in/PaymentExpiringSoonSchedulerTest.java
@@ -1,0 +1,155 @@
+package com.bugzero.rarego.in;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.bugzero.rarego.app.PaymentFacade;
+import com.bugzero.rarego.out.AuctionOrderApiClient;
+import com.bugzero.rarego.shared.auction.dto.AuctionOrderDto;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentExpiringSoonSchedulerTest {
+
+	@Mock
+	private AuctionOrderApiClient auctionOrderApiClient;
+
+	@Mock
+	private PaymentFacade paymentFacade;
+
+	@InjectMocks
+	private PaymentExpiringSoonScheduler scheduler;
+
+	@BeforeEach
+	void setUp() {
+		// @Value("${auction.payment-timeout-days:3}") 값을 주입
+		ReflectionTestUtils.setField(scheduler, "paymentTimeoutDays", 3);
+	}
+
+	@Test
+	@DisplayName("마감 임박 주문이 없으면 아무 동작도 하지 않고 종료된다")
+	void checkExpiringSoon_empty() {
+		// given
+		// 첫 번째 조회에서 바로 빈 리스트 반환
+		given(auctionOrderApiClient.findExpiringSoonOrders(any(), any()))
+			.willReturn(new AuctionOrderApiClient.AuctionOrderSlice(Collections.emptyList(), false));
+
+		// when
+		scheduler.checkExpiringSoon();
+
+		// then
+		then(paymentFacade).should(never()).publishExpiringSoonEvent(any(), any());
+		then(auctionOrderApiClient).should(never()).markAsNoticed(any());
+	}
+
+	@Test
+	@DisplayName("마감 임박 주문이 있으면 이벤트를 발행하고 알림 완료 처리를 한다")
+	void checkExpiringSoon_success() {
+		// given
+		AuctionOrderDto order1 = createOrderDto(1L);
+		AuctionOrderDto order2 = createOrderDto(2L);
+
+		// 1. 첫 번째 조회: 주문 2개 반환
+		// 2. 두 번째 조회: 빈 리스트 반환 (루프 종료용)
+		given(auctionOrderApiClient.findExpiringSoonOrders(any(), eq(PageRequest.of(0, 100))))
+			.willReturn(new AuctionOrderApiClient.AuctionOrderSlice(List.of(order1, order2), true))
+			.willReturn(new AuctionOrderApiClient.AuctionOrderSlice(Collections.emptyList(), false));
+
+		// when
+		scheduler.checkExpiringSoon();
+
+		// then
+		// 1. 이벤트 발행 검증 (총 2회)
+		then(paymentFacade).should(times(1)).publishExpiringSoonEvent(eq(order1), any(LocalDateTime.class));
+		then(paymentFacade).should(times(1)).publishExpiringSoonEvent(eq(order2), any(LocalDateTime.class));
+
+		// 2. 상태 마킹 검증 (총 2회)
+		then(auctionOrderApiClient).should(times(1)).markAsNoticed(order1.orderId());
+		then(auctionOrderApiClient).should(times(1)).markAsNoticed(order2.orderId());
+	}
+
+	@Test
+	@DisplayName("처리 중 예외가 발생해도 다음 주문 처리는 계속된다")
+	void checkExpiringSoon_continueOnError() {
+		// given
+		// 1. 서로 다른 ID를 가진 객체 생성 확인
+		AuctionOrderDto successOrder = createOrderDto(1L);
+		AuctionOrderDto failOrder = createOrderDto(2L);
+		AuctionOrderDto nextOrder = createOrderDto(3L);
+
+		// 2. ApiClient Mocking
+		given(auctionOrderApiClient.findExpiringSoonOrders(any(), any()))
+			.willReturn(new AuctionOrderApiClient.AuctionOrderSlice(List.of(successOrder, failOrder, nextOrder), true))
+			.willReturn(new AuctionOrderApiClient.AuctionOrderSlice(Collections.emptyList(), false));
+
+		// 3. PaymentFacade Mocking (중요!)
+		// failOrder(ID 2)일 때만 예외 발생
+		lenient().doThrow(new RuntimeException("Kafka Error"))
+			.when(paymentFacade).publishExpiringSoonEvent(eq(failOrder), any());
+
+		// when
+		scheduler.checkExpiringSoon();
+
+		// then
+		// 1번(성공)과 3번(성공)은 마킹이 호출되어야 함
+		then(auctionOrderApiClient).should().markAsNoticed(1L); // successOrder
+		then(auctionOrderApiClient).should().markAsNoticed(3L); // nextOrder
+
+		// 2번(실패)은 마킹이 호출되지 않아야 함
+		then(auctionOrderApiClient).should(never()).markAsNoticed(2L); // failOrder
+	}
+
+	@Test
+	@DisplayName("조회 시 계산된 날짜 파라미터가 정상적으로 전달되는지 검증")
+	void verify_date_calculation() {
+		// given
+		given(auctionOrderApiClient.findExpiringSoonOrders(any(), any()))
+			.willReturn(new AuctionOrderApiClient.AuctionOrderSlice(Collections.emptyList(), false));
+
+		ArgumentCaptor<LocalDateTime> dateCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+
+		// when
+		scheduler.checkExpiringSoon();
+
+		// then
+		then(auctionOrderApiClient).should().findExpiringSoonOrders(dateCaptor.capture(), any());
+
+		LocalDateTime capturedDate = dateCaptor.getValue();
+		// 오늘 날짜 - 3일
+		// 시간은 LocalTime.MAX (23:59:59...) 인지 확인
+		LocalDateTime expectedDate = java.time.LocalDate.now().minusDays(3).atTime(java.time.LocalTime.MAX);
+
+		// 초 단위 차이 무시하고 비교 (실행 속도 차이 고려)
+		// 여기서는 날짜와 시간이 정확한지 AssertJ 등으로 검증 가능
+		assertThat(capturedDate).isEqualToIgnoringNanos(expectedDate);
+	}
+
+	// 테스트용 DTO 생성 헬퍼
+	private AuctionOrderDto createOrderDto(Long id) {
+		// 필요한 필드만 채워서 생성 (Record라고 가정)
+		return new AuctionOrderDto(
+			id,       // orderId
+			100L,     // auctionId
+			200L,     // buyerId
+			300L,     // sellerId
+			10000,
+			"PROCESSING",
+			LocalDateTime.now()
+		);
+	}
+}

--- a/payment-service/src/test/java/com/bugzero/rarego/out/PaymentKafkaConnectionTest.java
+++ b/payment-service/src/test/java/com/bugzero/rarego/out/PaymentKafkaConnectionTest.java
@@ -1,0 +1,127 @@
+package com.bugzero.rarego.out;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.context.TestPropertySource;
+
+import com.bugzero.rarego.shared.payment.dto.SettlementResponseDto;
+import com.bugzero.rarego.shared.payment.event.AuctionPaymentCompletedEvent;
+import com.bugzero.rarego.shared.payment.event.AuctionPaymentExpiringSoonEvent;
+import com.bugzero.rarego.shared.payment.event.SettlementFinishedEvent;
+
+@SpringBootTest(classes = {KafkaAutoConfiguration.class})
+@TestPropertySource(properties = {
+	"spring.kafka.bootstrap-servers=localhost:29092",
+	"spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer",
+	"spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JacksonJsonSerializer"
+})
+class PaymentKafkaConnectionTest {
+
+	@Autowired
+	private KafkaTemplate<String, Object> kafkaTemplate;
+
+	// Bridge에서 사용하는 토픽명과 일치해야 함
+	private static final String TOPIC_SETTLEMENT = "payment-settlement-finished";
+	private static final String TOPIC_PAYMENT_COMPLETED = "payment-auction-completed";
+	private static final String TOPIC_EXPIRING_SOON = "payment-auction-expiring-soon";
+
+	@Test
+	@DisplayName("1. 정산 완료 이벤트(SettlementFinishedEvent) 전송 테스트")
+	void testSend_SettlementFinished() {
+		// 1. DTO 생성 (Record 생성자 사용 - 8개 필드)
+		SettlementResponseDto dto1 = new SettlementResponseDto(
+			1L,                 // id
+			100L,               // auctionId
+			200L,               // sellerId
+			10000,              // salesAmount (판매가)
+			1000,               // feeAmount (수수료)
+			9000,               // settlementAmount (정산금)
+			"COMPLETED",        // status
+			LocalDateTime.now() // createdAt
+		);
+
+		List<SettlementResponseDto> settlements = List.of(dto1);
+
+		// 2. 이벤트 생성 (of 메서드 대신 생성자 직접 사용)
+		// totalCount와 totalAmount를 직접 넣어줍니다.
+		SettlementFinishedEvent event = new SettlementFinishedEvent(
+			settlements,
+			1,     // totalCount
+			9000   // totalAmount
+		);
+
+		String key = UUID.randomUUID().toString();
+
+		// 3. 전송 및 로그 확인
+		sendAndLog(TOPIC_SETTLEMENT, key, event);
+	}
+
+	@Test
+	@DisplayName("2. 낙찰 결제 완료 이벤트(AuctionPaymentCompletedEvent) 전송 테스트")
+	void testSend_AuctionPaymentCompleted() {
+		// given
+		AuctionPaymentCompletedEvent event = new AuctionPaymentCompletedEvent(
+			123L, // orderId
+			456L, // auctionId
+			999L, // sellerId (추가됨)
+			789L, // buyerId
+			15000 // amount
+		);
+
+		String key = String.valueOf(event.auctionId()); // Key: auctionId
+
+		// when & then
+		sendAndLog(TOPIC_PAYMENT_COMPLETED, key, event);
+	}
+
+	@Test
+	@DisplayName("3. 마감 임박 알림 이벤트(AuctionPaymentExpiringSoonEvent) 전송 테스트")
+	void testSend_ExpiringSoon() {
+		// given
+		AuctionPaymentExpiringSoonEvent event = new AuctionPaymentExpiringSoonEvent(
+			111L, // orderId
+			222L, // auctionId
+			333L, // buyerId
+			444L, // sellerId
+			20000, // amount
+			LocalDateTime.now().plusHours(12) // expiredAt
+		);
+
+		String key = String.valueOf(event.auctionId()); // Key: auctionId
+
+		// when & then
+		sendAndLog(TOPIC_EXPIRING_SOON, key, event);
+	}
+
+	/**
+	 * 전송 및 결과 로그 출력 헬퍼 메서드
+	 */
+	private void sendAndLog(String topic, String key, Object event) {
+		try {
+			System.out.println(">>> 전송 시도: Topic=" + topic + ", Key=" + key);
+
+			// 실제 전송 (최대 3초 대기)
+			SendResult<String, Object> result = kafkaTemplate.send(topic, key, event)
+				.get(3, TimeUnit.SECONDS);
+
+			System.out.println("✅ 전송 성공!");
+			System.out.println("   - Offset: " + result.getRecordMetadata().offset());
+			System.out.println("   - Partition: " + result.getRecordMetadata().partition());
+			System.out.println("--------------------------------------------------");
+
+		} catch (Exception e) {
+			System.err.println("❌ 전송 실패: " + e.getMessage());
+			throw new RuntimeException("Kafka 전송 실패", e);
+		}
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #333 

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

- [x] AuctionPaymentExpringSoonEvent 카프카 발행
- [x] 스케줄러로 매일 오전 10시에 당일 마감되는 결제 건에 대해 이벤트를 발행
- [x] 중복 이벤트 발행을 방지하기 위해 AuctionOrder  테이블에 noticedAt 필드 추가

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- 결제 타입 아웃 스케줄러와 동시간에 도는 것을 피하고 유저를 배려한 알림을 위해 오전 10시에 스케줄러 돌려서 알림 보내는 것으로 정했습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
15분