### PR TITLE
[FEAT/notification] 이벤트 수신하여 알림으로 저장

### DIFF
--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
@@ -1,0 +1,49 @@
+package com.bugzero.rarego.app;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bugzero.rarego.app.mapper.NotificationMapper;
+import com.bugzero.rarego.domain.Notification;
+import com.bugzero.rarego.out.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationCreateNotificationUseCase {
+	private final NotificationRepository notificationRepository;
+	private final List<NotificationMapper<?>> mappers;
+
+	@SuppressWarnings("unchecked")
+	@Transactional
+	public void createNotification(Object event) {
+		Optional<NotificationMapper<Object>> mapperOptional = (Optional)mappers.stream()
+			.filter(m -> m.supports(event))
+			.findFirst();
+
+		// 에러를 던지지 않고 로그만 찍고 넘어감 -> 에러 던지면 kafka 무한 재시도
+		if (mapperOptional.isEmpty()) {
+			log.error("지원하지 않는 알림 이벤트가 감지되었습니다. mapper에 등록해주세요. Event: {}", event.getClass().getSimpleName());
+			return;
+		}
+
+		NotificationMapper<Object> mapper = mapperOptional.get();
+		List<Notification> notifications = mapper.map(event);
+
+		if (notifications.isEmpty()) {
+			log.warn("[알림] 생성된 알림이 없습니다. Event: {}", event.getClass().getSimpleName());
+			return;
+		}
+
+		notificationRepository.saveAll(notifications);
+
+		log.info("[알림] 저장 완료. 타입: {}, 개수: {}건",
+			event.getClass().getSimpleName(), notifications.size());
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
@@ -34,8 +34,7 @@ public class NotificationCreateNotificationUseCase {
 			return;
 		}
 
-		NotificationMapper<Object> mapper = mapperOptional.get();
-		List<Notification> notifications = mapper.map(event);
+		List<Notification> notifications = mapperOptional.get().map(event);
 
 		if (notifications.isEmpty()) {
 			log.warn("[알림] 생성된 알림이 없습니다. Event: {}", event.getClass().getSimpleName());
@@ -46,13 +45,12 @@ public class NotificationCreateNotificationUseCase {
 			saveWithIdempotency(notification);
 		}
 
-		log.info("[알림] 저장 완료. 타입: {}, 개수: {}건",
-			event.getClass().getSimpleName(), notifications.size());
+		log.info("[알림] 저장 완료. 타입: {}, 개수: {}건", event.getClass().getSimpleName(), notifications.size());
 	}
 
 	private void saveWithIdempotency(Notification notification) {
 		try {
-			notificationRepository.save(notification);
+			notificationRepository.saveAndFlush(notification);
 		} catch (DataIntegrityViolationException e) {
 			// 이미 DB에 존재하는 경우 (Unique Constraint 위배)
 			log.warn("[알림 중복 무시] 이미 존재하는 알림입니다. MemberId: {}, Type: {}, RefId: {}",

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
@@ -3,6 +3,7 @@ package com.bugzero.rarego.app;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,9 +42,23 @@ public class NotificationCreateNotificationUseCase {
 			return;
 		}
 
-		notificationRepository.saveAll(notifications);
+		for (Notification notification : notifications) {
+			saveWithIdempotency(notification);
+		}
 
 		log.info("[알림] 저장 완료. 타입: {}, 개수: {}건",
 			event.getClass().getSimpleName(), notifications.size());
+	}
+
+	private void saveWithIdempotency(Notification notification) {
+		try {
+			notificationRepository.save(notification);
+		} catch (DataIntegrityViolationException e) {
+			// 이미 DB에 존재하는 경우 (Unique Constraint 위배)
+			log.warn("[알림 중복 무시] 이미 존재하는 알림입니다. MemberId: {}, Type: {}, RefId: {}",
+				notification.getMember().getId(),
+				notification.getType(),
+				notification.getReferenceId());
+		}
 	}
 }

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
@@ -27,7 +27,7 @@ public class NotificationCreateNotificationUseCase {
 			.filter(m -> m.supports(event))
 			.findFirst();
 
-		// 에러를 던지지 않고 로그만 찍고 넘어감 -> 에러 던지면 kafka 무한 재시도
+		// 에러를 던지지 않고 로그만 찍고 넘어감 -> 에러 던지면 kafka 재시도
 		if (mapperOptional.isEmpty()) {
 			log.error("지원하지 않는 알림 이벤트가 감지되었습니다. mapper에 등록해주세요. Event: {}", event.getClass().getSimpleName());
 			return;

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCase.java
@@ -53,10 +53,28 @@ public class NotificationCreateNotificationUseCase {
 			notificationRepository.saveAndFlush(notification);
 		} catch (DataIntegrityViolationException e) {
 			// 이미 DB에 존재하는 경우 (Unique Constraint 위배)
-			log.warn("[알림 중복 무시] 이미 존재하는 알림입니다. MemberId: {}, Type: {}, RefId: {}",
-				notification.getMember().getId(),
-				notification.getType(),
-				notification.getReferenceId());
+			if (isDuplicateEntryException(e)) {
+
+				log.warn("[알림 중복 무시] 이미 존재하는 알림입니다. MemberId: {}, Type: {}, RefId: {}",
+					notification.getMember().getId(),
+					notification.getType(),
+					notification.getReferenceId());
+				return;
+			}
+
+			log.error("중복이 아닌 심각한 오류 발생, 알림 저장 실패.", e);
+			throw e;
 		}
+	}
+
+	private boolean isDuplicateEntryException(DataIntegrityViolationException e) {
+		Throwable cause = e.getMostSpecificCause();
+
+		// 우리가 Entity에 설정한 제약조건 이름: "uk_notification_dedup"
+		String message = cause.getMessage();
+		return message != null && (
+			message.contains("uk_notification_dedup") || // 우리가 지정한 제약조건명
+				message.contains("Duplicate entry")          // MySQL 메시지 패턴
+		);
 	}
 }

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationFacade.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationFacade.java
@@ -1,0 +1,15 @@
+package com.bugzero.rarego.app;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationFacade {
+	private final NotificationCreateNotificationUseCase notificationCreateNotificationUseCase;
+
+	public void createNotification(Object event) {
+		notificationCreateNotificationUseCase.createNotification(event);
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationSupport.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationSupport.java
@@ -1,0 +1,25 @@
+package com.bugzero.rarego.app;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bugzero.rarego.domain.NotificationMember;
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
+import com.bugzero.rarego.out.NotificationMemberRepository;
+import com.bugzero.rarego.out.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationSupport {
+	private final NotificationRepository notificationRepository;
+	private final NotificationMemberRepository notificationMemberRepository;
+
+	@Transactional(readOnly = true)
+	public NotificationMember findMemberById(Long memberId) {
+		return notificationMemberRepository.findById(memberId)
+			.orElseThrow(() -> new CustomException(ErrorType.MEMBER_NOT_FOUND));
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/app/mapper/AuctionEndedMapper.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/mapper/AuctionEndedMapper.java
@@ -1,0 +1,41 @@
+package com.bugzero.rarego.app.mapper;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.app.NotificationSupport;
+import com.bugzero.rarego.domain.Notification;
+import com.bugzero.rarego.domain.NotificationMember;
+import com.bugzero.rarego.domain.NotificationType;
+import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionEndedMapper implements NotificationMapper<AuctionEndedEvent> {
+	private final NotificationSupport notificationSupport;
+
+	@Override
+	public boolean supports(Object event) {
+		return event instanceof AuctionEndedEvent;
+	}
+
+	@Override
+	public List<Notification> map(AuctionEndedEvent event) {
+		String message = "축하합니다. %d번 경매의 상품을 %d원에 낙찰받았습니다.%n결제를 진행해주세요."
+			.formatted(event.auctionId(), event.finalPrice());
+
+		NotificationMember member = notificationSupport.findMemberById(event.winnerId());
+
+		Notification notification = Notification.builder()
+			.message(message)
+			.member(member)
+			.type(NotificationType.AUCTION_WON)
+			.referenceId(event.auctionId())
+			.build();
+
+		return List.of(notification);
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/app/mapper/AuctionPaymentCompletedMapper.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/mapper/AuctionPaymentCompletedMapper.java
@@ -1,0 +1,42 @@
+package com.bugzero.rarego.app.mapper;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.app.NotificationSupport;
+import com.bugzero.rarego.domain.Notification;
+import com.bugzero.rarego.domain.NotificationMember;
+import com.bugzero.rarego.domain.NotificationType;
+import com.bugzero.rarego.shared.payment.event.AuctionPaymentCompletedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionPaymentCompletedMapper implements NotificationMapper<AuctionPaymentCompletedEvent> {
+	private final NotificationSupport notificationSupport;
+
+	@Override
+	public boolean supports(Object event) {
+		return event instanceof AuctionPaymentCompletedEvent;
+	}
+
+	@Override
+	public List<Notification> map(AuctionPaymentCompletedEvent event) {
+		NotificationMember buyer = notificationSupport.findMemberById(event.buyerId());
+		NotificationMember seller = notificationSupport.findMemberById(event.sellerId());
+
+		String message = "%s님이 %d번 경매의 결제를 완료했습니다.%n판매 대금은 정산 이후 지급됩니다."
+			.formatted(buyer.getNickname(), event.auctionId());
+
+		Notification notification = Notification.builder()
+			.message(message)
+			.member(seller)
+			.type(NotificationType.AUCTION_PAYMENT_COMPLETED)
+			.referenceId(event.auctionId())
+			.build();
+
+		return List.of(notification);
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/app/mapper/AuctionPaymentExpiringSoonMapper.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/mapper/AuctionPaymentExpiringSoonMapper.java
@@ -1,0 +1,45 @@
+package com.bugzero.rarego.app.mapper;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.app.NotificationSupport;
+import com.bugzero.rarego.domain.Notification;
+import com.bugzero.rarego.domain.NotificationMember;
+import com.bugzero.rarego.domain.NotificationType;
+import com.bugzero.rarego.shared.payment.event.AuctionPaymentExpiringSoonEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionPaymentExpiringSoonMapper implements NotificationMapper<AuctionPaymentExpiringSoonEvent> {
+	private final NotificationSupport notificationSupport;
+
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("MM월 dd일 HH시 mm분");
+
+	@Override
+	public boolean supports(Object event) {
+		return event instanceof AuctionPaymentExpiringSoonEvent;
+	}
+
+	@Override
+	public List<Notification> map(AuctionPaymentExpiringSoonEvent event) {
+		NotificationMember buyer = notificationSupport.findMemberById(event.buyerId());
+		String deadline = event.expiredAt().format(FORMATTER);
+
+		String message = "%d번 경매의 결제 마감 시간이 임박했습니다.%n%s까지 결제를 완료해주세요."
+			.formatted(event.auctionId(), deadline);
+
+		Notification notification = Notification.builder()
+			.message(message)
+			.member(buyer)
+			.type(NotificationType.AUCTION_PAYMENT_EXPIRING_SOON)
+			.referenceId(event.orderId())
+			.build();
+
+		return List.of(notification);
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/app/mapper/NotificationMapper.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/mapper/NotificationMapper.java
@@ -1,0 +1,11 @@
+package com.bugzero.rarego.app.mapper;
+
+import java.util.List;
+
+import com.bugzero.rarego.domain.Notification;
+
+public interface NotificationMapper<T> {
+	boolean supports(Object event);
+
+	List<Notification> map(T event);
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/app/mapper/SettlementFinishedMapper.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/mapper/SettlementFinishedMapper.java
@@ -1,0 +1,46 @@
+package com.bugzero.rarego.app.mapper;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.app.NotificationSupport;
+import com.bugzero.rarego.domain.Notification;
+import com.bugzero.rarego.domain.NotificationMember;
+import com.bugzero.rarego.domain.NotificationType;
+import com.bugzero.rarego.shared.payment.dto.SettlementResponseDto;
+import com.bugzero.rarego.shared.payment.event.SettlementFinishedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SettlementFinishedMapper implements NotificationMapper<SettlementFinishedEvent> {
+	private final NotificationSupport notificationSupport;
+
+	@Override
+	public boolean supports(Object event) {
+		return event instanceof SettlementFinishedEvent;
+	}
+
+	@Override
+	public List<Notification> map(SettlementFinishedEvent event) {
+		return event.settlements().stream()
+			.map(this::createNotificationFromDto)
+			.toList();
+	}
+
+	private Notification createNotificationFromDto(SettlementResponseDto dto) {
+		NotificationMember seller = notificationSupport.findMemberById(dto.sellerId());
+
+		String message = "%d번 경매의 판매 대금 %d원이 정산되었습니다."
+			.formatted(dto.auctionId(), dto.settlementAmount());
+
+		return Notification.builder()
+			.message(message)
+			.member(seller)
+			.type(NotificationType.SETTLEMENT_COMPLETED)
+			.referenceId(dto.id())
+			.build();
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/domain/Notification.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/domain/Notification.java
@@ -22,13 +22,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-
 @Table(
 	name = "NOTIFICATION_NOTIFICATION",
 	uniqueConstraints = {
 		@UniqueConstraint(
-			name = "uk_notification_dedup", // 제약조건 이름 (DB 에러 로그에서 확인 용이)
-			columnNames = {"reference_id", "type", "member_id"} // ✅ 3개 조합 유니크
+			name = "uk_notification_dedup",
+			columnNames = {"reference_id", "type", "member_id"}
 		)
 	}
 )
@@ -36,9 +35,6 @@ public class Notification extends BaseIdAndTime {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(nullable = false)
 	private NotificationMember member;
-
-	@Column(nullable = false)
-	private String title;
 
 	@Column(nullable = false)
 	private String message;
@@ -53,7 +49,4 @@ public class Notification extends BaseIdAndTime {
 
 	@Column(nullable = false)
 	private Long referenceId;
-
-	private String link;
-
 }

--- a/notification-service/src/main/java/com/bugzero/rarego/in/NotificationConsumer.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/in/NotificationConsumer.java
@@ -1,0 +1,75 @@
+package com.bugzero.rarego.in;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.app.NotificationFacade;
+import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
+import com.bugzero.rarego.shared.payment.event.AuctionPaymentCompletedEvent;
+import com.bugzero.rarego.shared.payment.event.AuctionPaymentExpiringSoonEvent;
+import com.bugzero.rarego.shared.payment.event.SettlementFinishedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationConsumer {
+	private final NotificationFacade notificationFacade;
+	private static final String GROUP_ID = "${spring.kafka.consumer.group-id}";
+
+	/**
+	 * 낙찰 결제 완료
+	 */
+	@KafkaListener(topics = "payment-auction-completed", groupId = GROUP_ID)
+	public void consumePaymentCompleted(AuctionPaymentCompletedEvent event) {
+		log.info(">> [Kafka] 결제 완료 이벤트 수신: auctionId={}", event.auctionId());
+		notificationFacade.createNotification(event);
+	}
+
+	/**
+	 * 낙찰 결제 마감 임박
+	 */
+	@KafkaListener(topics = "payment-auction-expiring-soon", groupId = GROUP_ID)
+	public void consumeExpiringSoon(AuctionPaymentExpiringSoonEvent event) {
+		log.info(">> [Kafka] 마감 임박 이벤트 수신: auctionId={}", event.auctionId());
+		notificationFacade.createNotification(event);
+	}
+
+	/**
+	 * 정산 완료
+	 */
+	@KafkaListener(topics = "payment-settlement-finished", groupId = GROUP_ID)
+	public void consumeSettlementFinished(SettlementFinishedEvent event) {
+		log.info(">> [Kafka] 정산 완료 이벤트 수신: 총 {}건", event.settlements().size());
+		notificationFacade.createNotification(event);
+	}
+
+	/**
+	 * 낙찰 성공
+	 */
+	@KafkaListener(topics = "auction-ended", groupId = GROUP_ID)
+	public void consumeAuctionEnded(AuctionEndedEvent event) {
+		log.info(">> [Kafka] 경매 낙찰 이벤트 수신: auctionId={}", event.auctionId());
+		notificationFacade.createNotification(event);
+	}
+
+	/**
+	 * 입찰가 추월
+	 */
+	// @KafkaListener(topics = "auction-outbid", groupId = GROUP_ID)
+	// public void consumeOutbid(OutbidEvent event) {
+	// 	log.info(">> [Kafka] 입찰가 추월 이벤트 수신: auctionId={}", event.auctionId());
+	// 	notificationService.createNotification(event);
+	// }
+
+	/**
+	 * 관심 경매 시작
+	 */
+	// @KafkaListener(topics = "auction-started", groupId = GROUP_ID)
+	// public void consumeAuctionStarted(AuctionStartedEvent event) {
+	// 	log.info(">> [Kafka] 관심 경매 시작 이벤트 수신: auctionId={}", event.auctionId());
+	// 	notificationService.createNotification(event);
+	// }
+}

--- a/notification-service/src/test/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCaseTest.java
+++ b/notification-service/src/test/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCaseTest.java
@@ -1,0 +1,98 @@
+package com.bugzero.rarego.app;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.bugzero.rarego.app.mapper.NotificationMapper;
+import com.bugzero.rarego.domain.Notification;
+import com.bugzero.rarego.out.NotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCreateNotificationUseCaseTest {
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@Mock
+	private NotificationMapper<Object> notificationMapper;
+
+	private NotificationCreateNotificationUseCase useCase;
+
+	@BeforeEach
+	void setUp() {
+		// 매퍼 리스트에 Mock 매퍼 하나를 넣어서 주입
+		List<NotificationMapper<?>> mappers = List.of(notificationMapper);
+		useCase = new NotificationCreateNotificationUseCase(notificationRepository, mappers);
+	}
+
+	@Test
+	@DisplayName("성공: 지원하는 이벤트가 들어오면 알림을 생성하고 저장한다.")
+	void createNotification_success() {
+		// given
+		TestEvent event = new TestEvent(1L);
+		Notification notification = mock(Notification.class); // 내부 값은 중요하지 않으므로 Mock 처리
+
+		// 매퍼가 이 이벤트를 지원한다고 설정
+		given(notificationMapper.supports(event)).willReturn(true);
+		// 매퍼가 변환 결과로 알림 리스트를 반환한다고 설정
+		given(notificationMapper.map(event)).willReturn(List.of(notification));
+
+		// when
+		useCase.createNotification(event);
+
+		// then
+		// 리포지토리의 saveAll이 1번 호출되었는지 검증
+		then(notificationRepository).should().saveAll(List.of(notification));
+	}
+
+	@Test
+	@DisplayName("실패: 지원하지 않는 이벤트가 들어오면 저장하지 않고 로그만 남긴다(무시한다).")
+	void createNotification_fail_not_supported() {
+		// given
+		TestEvent event = new TestEvent(1L);
+
+		// 매퍼가 이 이벤트를 지원하지 않는다고 설정 (false)
+		given(notificationMapper.supports(event)).willReturn(false);
+
+		// when
+		useCase.createNotification(event);
+
+		// then
+		// map 메서드는 호출되지 않아야 함
+		then(notificationMapper).should(never()).map(any());
+		// 리포지토리 save는 절대 호출되지 않아야 함
+		then(notificationRepository).should(never()).saveAll(any());
+	}
+
+	@Test
+	@DisplayName("실패: 매퍼가 빈 리스트를 반환하면 저장하지 않는다.")
+	void createNotification_fail_empty_list() {
+		// given
+		TestEvent event = new TestEvent(1L);
+
+		// 지원은 하지만
+		given(notificationMapper.supports(event)).willReturn(true);
+		// 결과가 비어있음 (예: 조건에 맞지 않아 알림 생성 안 함)
+		given(notificationMapper.map(event)).willReturn(Collections.emptyList());
+
+		// when
+		useCase.createNotification(event);
+
+		// then
+		// 리포지토리 save는 호출되지 않아야 함
+		then(notificationRepository).should(never()).saveAll(any());
+	}
+
+	// 테스트용 이벤트 클래스
+	record TestEvent(Long id) {
+	}
+}

--- a/notification-service/src/test/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCaseTest.java
+++ b/notification-service/src/test/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.bugzero.rarego.app;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.Collections;
@@ -36,7 +37,7 @@ class NotificationCreateNotificationUseCaseTest {
 	}
 
 	@Test
-	@DisplayName("성공: 지원하는 이벤트가 들어오면 알림을 생성하고 '단건으로' 저장한다.")
+	@DisplayName("성공: 지원하는 이벤트가 들어오면 알림을 변환하고 '즉시 저장(saveAndFlush)'한다.")
 	void createNotification_success() {
 		// given
 		TestEvent event = new TestEvent(1L);
@@ -49,12 +50,12 @@ class NotificationCreateNotificationUseCaseTest {
 		useCase.createNotification(event);
 
 		// then
-		// [변경] saveAll이 아니라 save가 호출되었는지 검증
-		then(notificationRepository).should(times(1)).save(notification);
+		// [변경] 트랜잭션 내 예외 포착을 위해 saveAndFlush 호출 검증
+		then(notificationRepository).should(times(1)).saveAndFlush(notification);
 	}
 
 	@Test
-	@DisplayName("성공(중복무시): 이미 존재하는 알림(중복)이라면 에러를 무시하고 정상 종료한다.")
+	@DisplayName("성공(중복무시): 'Duplicate entry' 예외가 발생하면 로그를 남기고 정상 종료한다.")
 	void createNotification_success_duplicate() {
 		// given
 		TestEvent event = new TestEvent(1L);
@@ -64,25 +65,52 @@ class NotificationCreateNotificationUseCaseTest {
 		given(notificationMapper.supports(event)).willReturn(true);
 		given(notificationMapper.map(event)).willReturn(List.of(notification));
 
-		// [중요] 예외 발생 시 로그를 찍기 위해 notification.getMember().getId()를 호출함.
-		// Mock 객체이므로 NullPointerException 방지를 위해 Member 스텁핑 필요
+		// 로그 출력을 위한 Mock Stubbing
 		given(notification.getMember()).willReturn(member);
 
-		// [핵심] 저장 시 DataIntegrityViolationException 예외가 터지도록 설정
-		willThrow(new DataIntegrityViolationException("Duplicate entry"))
-			.given(notificationRepository).save(notification);
+		// [핵심] 예외 메시지에 "Duplicate entry"가 포함되어야 로직에서 중복으로 인식함
+		DataIntegrityViolationException duplicateException =
+			new DataIntegrityViolationException("Duplicate entry '1-OUTBID' for key 'uk_notification_dedup'");
+
+		willThrow(duplicateException)
+			.given(notificationRepository).saveAndFlush(notification);
 
 		// when
-		// 예외가 던져지지 않아야 테스트 통과 (try-catch 작동 확인)
 		useCase.createNotification(event);
 
 		// then
-		// 저장은 시도했으나 예외를 삼켰음을 검증
-		then(notificationRepository).should(times(1)).save(notification);
+		// 예외가 던져지지 않고(Swallowed), 저장 시도는 했음을 검증
+		then(notificationRepository).should(times(1)).saveAndFlush(notification);
 	}
 
 	@Test
-	@DisplayName("실패: 지원하지 않는 이벤트가 들어오면 저장하지 않고 로그만 남긴다(무시한다).")
+	@DisplayName("실패: 중복이 아닌 다른 데이터 무결성 예외(FK, NotNull 등)는 다시 던져야 한다.")
+	void createNotification_fail_integrity_violation() {
+		// given
+		TestEvent event = new TestEvent(1L);
+		Notification notification = mock(Notification.class);
+
+		given(notificationMapper.supports(event)).willReturn(true);
+		given(notificationMapper.map(event)).willReturn(List.of(notification));
+
+		// [핵심] 중복 키워드가 없는 다른 종류의 예외 생성
+		DataIntegrityViolationException otherException =
+			new DataIntegrityViolationException("Column 'message' cannot be null");
+
+		willThrow(otherException)
+			.given(notificationRepository).saveAndFlush(notification);
+
+		// when & then
+		// 중복이 아니므로 예외가 밖으로 던져져야 함 -> Kafka 재시도 유도
+		assertThatThrownBy(() -> useCase.createNotification(event))
+			.isInstanceOf(DataIntegrityViolationException.class)
+			.hasMessageContaining("cannot be null");
+
+		then(notificationRepository).should(times(1)).saveAndFlush(notification);
+	}
+
+	@Test
+	@DisplayName("실패: 지원하지 않는 이벤트가 들어오면 저장하지 않는다.")
 	void createNotification_fail_not_supported() {
 		// given
 		TestEvent event = new TestEvent(1L);
@@ -94,8 +122,7 @@ class NotificationCreateNotificationUseCaseTest {
 
 		// then
 		then(notificationMapper).should(never()).map(any());
-		// [변경] saveAll -> save
-		then(notificationRepository).should(never()).save(any());
+		then(notificationRepository).should(never()).saveAndFlush(any());
 	}
 
 	@Test
@@ -111,8 +138,7 @@ class NotificationCreateNotificationUseCaseTest {
 		useCase.createNotification(event);
 
 		// then
-		// [변경] saveAll -> save
-		then(notificationRepository).should(never()).save(any());
+		then(notificationRepository).should(never()).saveAndFlush(any());
 	}
 
 	record TestEvent(Long id) {

--- a/notification-service/src/test/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCaseTest.java
+++ b/notification-service/src/test/java/com/bugzero/rarego/app/NotificationCreateNotificationUseCaseTest.java
@@ -11,9 +11,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import com.bugzero.rarego.app.mapper.NotificationMapper;
 import com.bugzero.rarego.domain.Notification;
+import com.bugzero.rarego.domain.NotificationMember;
 import com.bugzero.rarego.out.NotificationRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,29 +31,54 @@ class NotificationCreateNotificationUseCaseTest {
 
 	@BeforeEach
 	void setUp() {
-		// 매퍼 리스트에 Mock 매퍼 하나를 넣어서 주입
 		List<NotificationMapper<?>> mappers = List.of(notificationMapper);
 		useCase = new NotificationCreateNotificationUseCase(notificationRepository, mappers);
 	}
 
 	@Test
-	@DisplayName("성공: 지원하는 이벤트가 들어오면 알림을 생성하고 저장한다.")
+	@DisplayName("성공: 지원하는 이벤트가 들어오면 알림을 생성하고 '단건으로' 저장한다.")
 	void createNotification_success() {
 		// given
 		TestEvent event = new TestEvent(1L);
-		Notification notification = mock(Notification.class); // 내부 값은 중요하지 않으므로 Mock 처리
+		Notification notification = mock(Notification.class);
 
-		// 매퍼가 이 이벤트를 지원한다고 설정
 		given(notificationMapper.supports(event)).willReturn(true);
-		// 매퍼가 변환 결과로 알림 리스트를 반환한다고 설정
 		given(notificationMapper.map(event)).willReturn(List.of(notification));
 
 		// when
 		useCase.createNotification(event);
 
 		// then
-		// 리포지토리의 saveAll이 1번 호출되었는지 검증
-		then(notificationRepository).should().saveAll(List.of(notification));
+		// [변경] saveAll이 아니라 save가 호출되었는지 검증
+		then(notificationRepository).should(times(1)).save(notification);
+	}
+
+	@Test
+	@DisplayName("성공(중복무시): 이미 존재하는 알림(중복)이라면 에러를 무시하고 정상 종료한다.")
+	void createNotification_success_duplicate() {
+		// given
+		TestEvent event = new TestEvent(1L);
+		Notification notification = mock(Notification.class);
+		NotificationMember member = mock(NotificationMember.class);
+
+		given(notificationMapper.supports(event)).willReturn(true);
+		given(notificationMapper.map(event)).willReturn(List.of(notification));
+
+		// [중요] 예외 발생 시 로그를 찍기 위해 notification.getMember().getId()를 호출함.
+		// Mock 객체이므로 NullPointerException 방지를 위해 Member 스텁핑 필요
+		given(notification.getMember()).willReturn(member);
+
+		// [핵심] 저장 시 DataIntegrityViolationException 예외가 터지도록 설정
+		willThrow(new DataIntegrityViolationException("Duplicate entry"))
+			.given(notificationRepository).save(notification);
+
+		// when
+		// 예외가 던져지지 않아야 테스트 통과 (try-catch 작동 확인)
+		useCase.createNotification(event);
+
+		// then
+		// 저장은 시도했으나 예외를 삼켰음을 검증
+		then(notificationRepository).should(times(1)).save(notification);
 	}
 
 	@Test
@@ -60,17 +87,15 @@ class NotificationCreateNotificationUseCaseTest {
 		// given
 		TestEvent event = new TestEvent(1L);
 
-		// 매퍼가 이 이벤트를 지원하지 않는다고 설정 (false)
 		given(notificationMapper.supports(event)).willReturn(false);
 
 		// when
 		useCase.createNotification(event);
 
 		// then
-		// map 메서드는 호출되지 않아야 함
 		then(notificationMapper).should(never()).map(any());
-		// 리포지토리 save는 절대 호출되지 않아야 함
-		then(notificationRepository).should(never()).saveAll(any());
+		// [변경] saveAll -> save
+		then(notificationRepository).should(never()).save(any());
 	}
 
 	@Test
@@ -79,20 +104,17 @@ class NotificationCreateNotificationUseCaseTest {
 		// given
 		TestEvent event = new TestEvent(1L);
 
-		// 지원은 하지만
 		given(notificationMapper.supports(event)).willReturn(true);
-		// 결과가 비어있음 (예: 조건에 맞지 않아 알림 생성 안 함)
 		given(notificationMapper.map(event)).willReturn(Collections.emptyList());
 
 		// when
 		useCase.createNotification(event);
 
 		// then
-		// 리포지토리 save는 호출되지 않아야 함
-		then(notificationRepository).should(never()).saveAll(any());
+		// [변경] saveAll -> save
+		then(notificationRepository).should(never()).save(any());
 	}
 
-	// 테스트용 이벤트 클래스
 	record TestEvent(Long id) {
 	}
 }

--- a/notification-service/src/test/resources/application.yml
+++ b/notification-service/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  application:
+    name: notification-service
+
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
@@ -16,6 +19,17 @@ spring:
     redis:
       host: ${SPRING_DATA_REDIS_HOST:localhost}
       port: ${SPRING_DATA_REDIS_PORT:6379}
+
+  kafka:
+    consumer:
+      bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:29092}
+      group-id: ${spring.application.name}-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "*"
 
 jwt:
   secret: ${JWT_SECRET:dev-secret-key-have-to-change-abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklmnopqrstuvwxyz}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #341

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

- [x] 이벤트 -> 알림 변환 mapper 클래스 구현
- [x] kafka 이벤트 수신하여 알림 저장하는 로직 구현

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- 현재 이벤트에 상품명이 없어서 경매 id를 대신 사용중입니다. 추가되면 수정하겠습니다.
- 관심 경매 시작 알림을 위해서 AuctionStartedEvent에 해당 경매를 관심 등록한 회원 id 리스트가 필요합니다.
- 링크는 변할 수 있어서 db에 저장하기보다는 referenceId를 이용해서 생성해서 반환하는 로직으로 가려합니다.
- 회원 동기화가 이루어지지 않고 있어서 아직은 정상적으로 저장되지 않습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
10분