### PR TITLE
[FIX/infra] Nginx 기동 시 Upstream 호스트 해석 실패로 인한 무한 재시작 문제 해결

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -9,9 +9,13 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+    # DNS Resolver (Docker Internal DNS)
+    resolver 127.0.0.11 valid=30s;
+
     # Auth Service
     location ~ ^/(api/v1/auth|oauth2|login/oauth2) {
-        proxy_pass http://auth-service:8089;
+        set $auth_upstream auth-service:8089;
+        proxy_pass http://$auth_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -21,7 +25,8 @@ server {
 
     # Auction Service (Specific Member activities)
     location ~ ^/api/v1/members/me/(bids|sales|orders|bookmarks) {
-        proxy_pass http://auction-service:8083;
+        set $auction_upstream auction-service:8083;
+        proxy_pass http://$auction_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -31,7 +36,8 @@ server {
 
     # Auction Service
     location /api/v1/auctions {
-        proxy_pass http://auction-service:8083;
+        set $auction_upstream auction-service:8083;
+        proxy_pass http://$auction_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -48,7 +54,8 @@ server {
 
     # Payment Service
     location /api/v1/payments {
-        proxy_pass http://payment-service:8082;
+        set $payment_upstream payment-service:8082;
+        proxy_pass http://$payment_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -58,7 +65,8 @@ server {
 
     # Product Service
     location /api/v1/products {
-        proxy_pass http://product-service:8084;
+        set $product_upstream product-service:8084;
+        proxy_pass http://$product_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -68,7 +76,8 @@ server {
 
     # Member Service (General)
     location /api/v1/members {
-        proxy_pass http://member-service:8081;
+        set $member_upstream member-service:8081;
+        proxy_pass http://$member_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -78,14 +87,16 @@ server {
 
     # Swagger / API Docs
     location ~ ^/(api-docs|swagger-ui|v3/api-docs) {
-        proxy_pass http://auth-service:8089;
+        set $auth_upstream auth-service:8089;
+        proxy_pass http://$auth_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
     }
 
     # Frontend (Next.js)
     location / {
-        proxy_pass http://host.docker.internal:3000;
+        set $frontend_upstream host.docker.internal:3000;
+        proxy_pass http://$frontend_upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -98,7 +109,8 @@ server {
         auth_basic "Monitoring";
         auth_basic_user_file /etc/nginx/.htpasswd-monitoring;
 
-        proxy_pass http://grafana:3000;
+        set $grafana_upstream grafana:3000;
+        proxy_pass http://$grafana_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -110,7 +122,8 @@ server {
         auth_basic "Monitoring";
         auth_basic_user_file /etc/nginx/.htpasswd-monitoring;
 
-        proxy_pass http://prometheus:9090;
+        set $prometheus_upstream prometheus:9090;
+        proxy_pass http://$prometheus_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -135,9 +148,13 @@ server {
     listen 80;
     server_name rarego-nginx;
 
+    # DNS Resolver (Docker Internal DNS)
+    resolver 127.0.0.11 valid=30s;
+
     # Auth Service
     location ~ ^/(api/v1/auth|oauth2|login/oauth2) {
-        proxy_pass http://auth-service:8089;
+        set $auth_upstream auth-service:8089;
+        proxy_pass http://$auth_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -147,7 +164,8 @@ server {
 
     # Auction Service (Specific Member activities)
     location ~ ^/api/v1/members/me/(bids|sales|orders|bookmarks) {
-        proxy_pass http://auction-service:8083;
+        set $auction_upstream auction-service:8083;
+        proxy_pass http://$auction_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -157,7 +175,8 @@ server {
 
     # Auction Service
     location /api/v1/auctions {
-        proxy_pass http://auction-service:8083;
+        set $auction_upstream auction-service:8083;
+        proxy_pass http://$auction_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -174,7 +193,8 @@ server {
 
     # Payment Service
     location /api/v1/payments {
-        proxy_pass http://payment-service:8082;
+        set $payment_upstream payment-service:8082;
+        proxy_pass http://$payment_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -184,7 +204,8 @@ server {
 
     # Product Service
     location /api/v1/products {
-        proxy_pass http://product-service:8084;
+        set $product_upstream product-service:8084;
+        proxy_pass http://$product_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -194,7 +215,8 @@ server {
 
     # Member Service (General)
     location /api/v1/members {
-        proxy_pass http://member-service:8081;
+        set $member_upstream member-service:8081;
+        proxy_pass http://$member_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -206,7 +228,8 @@ server {
     # 외부 도메인(rarego.duckdns.org)에서는 접근 불가, 내부 게이트웨이(rarego-nginx)만 허용
 
     location /api/v1/internal/members {
-        proxy_pass http://member-service:8081;
+        set $member_upstream member-service:8081;
+        proxy_pass http://$member_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -215,7 +238,8 @@ server {
     }
 
     location /api/v1/internal/auctions {
-        proxy_pass http://auction-service:8083;
+        set $auction_upstream auction-service:8083;
+        proxy_pass http://$auction_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -224,7 +248,8 @@ server {
     }
 
     location /api/v1/internal/payments {
-        proxy_pass http://payment-service:8082;
+        set $payment_upstream payment-service:8082;
+        proxy_pass http://$payment_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -233,7 +258,8 @@ server {
     }
 
     location /api/v1/internal/auth {
-        proxy_pass http://auth-service:8089;
+        set $auth_upstream auth-service:8089;
+        proxy_pass http://$auth_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
# 🐛 버그 수정 PR

## #️⃣ 연관된 이슈
close: #359 

## 📝 수정 요약
- 🚨 문제점
  -  Nginx 컨테이너 기동 시, `auth-service` 등 업스트림 서비스가 도커 내부 DNS에 아직 등록되지 않았을 경우 `host not found in upstream "auth-service"` 에러를 내며 프로세스가 즉시 종료(emerg)되는 문제 발생
- 🔍 원인 분석
  - Nginx는 기본적으로 실행 시점에 설정 파일(`nginx.conf`)에 명시된 모든 주소를 IP로 변환하려고 시도함. 하나라도 실패하면 치명적 오류로 간주하고 종료됨.
  - 도커 DNS 등록 타이밍: 서비스 컨테이너가 뜬 직후 도커의 내장 DNS(`127.0.0.11`)에 이름이 등록되기 전의 초단위 찰나에 Nginx가 먼저 검사를 시도함.
- 💡 해결 방법
  - Runtime Resolving을 적용하여 기동 시점의 의존성을 제거
https://stackoverflow.com/questions/42720618/nginx-show-to-resolve-stopped-emerg-11-host-not-found-in-upstream

## 🛠️ PR 유형
- [x] 버그 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [ ] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
2분