### PR TITLE
[FEAT/payment] 보증금 rehold, 단건 release 로직 추가

### DIFF
--- a/common/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
+++ b/common/src/main/java/com/bugzero/rarego/global/response/ErrorType.java
@@ -123,7 +123,7 @@ public enum ErrorType {
 	ALREADY_USED_DEPOSIT(409, 4205, "이미 사용된 보증금입니다."),
 	PAYMENT_DEADLINE_EXCEEDED(400, 4206, "결제 기한이 지났습니다."),
 	SETTLEMENT_ALREADY_COMPLETED(400, 4207, "이미 정산이 완료되어 환불할 수 없습니다."),
-
+	INVALID_DEPOSIT_STATUS(400, 4208, "이미 예치 중이거나 처리된 보증금입니다."),
 	// Notification (5000 ~ 5999)
 	NOTIFICATION_NOT_FOUND(404, 5001, "알림이 존재하지 않습니다."),
 	NOTIFICATION_OWNER_MISMATCH(403, 5002, "알림에 대한 접근 권한이 없습니다."),

--- a/payment-service/src/main/java/com/bugzero/rarego/app/PaymentFacade.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/app/PaymentFacade.java
@@ -59,6 +59,13 @@ public class PaymentFacade {
 	}
 
 	/**
+	 * 보증금 단건 환급 (입찰 실패 시 보상 트랜잭션용)
+	 */
+	public void releaseDeposit(Long auctionId, String memberPublicId) {
+		paymentReleaseDepositUseCase.releaseDeposit(auctionId, memberPublicId);
+	}
+
+	/**
 	 * 예치금 결제 요청
 	 */
 	public PaymentRequestResponseDto requestPayment(String memberPublicId, PaymentRequestDto requestDto) {

--- a/payment-service/src/main/java/com/bugzero/rarego/app/PaymentHoldDepositUseCase.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/app/PaymentHoldDepositUseCase.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.bugzero.rarego.domain.Deposit;
+import com.bugzero.rarego.domain.DepositStatus;
 import com.bugzero.rarego.domain.PaymentMember;
 import com.bugzero.rarego.domain.PaymentTransaction;
 import com.bugzero.rarego.domain.ReferenceType;
@@ -24,7 +25,6 @@ public class PaymentHoldDepositUseCase {
 	private final PaymentTransactionRepository transactionRepository;
 	private final PaymentSupport paymentSupport;
 
-	@Transactional
 	public DepositHoldResponseDto holdDeposit(DepositHoldRequestDto request) {
 		// publicId → memberId 변환
 		PaymentMember member = paymentSupport.findMemberByPublicId(request.memberPublicId());
@@ -32,14 +32,49 @@ public class PaymentHoldDepositUseCase {
 
 		// 1. 멱등성 체크 (memberId로 조회)
 		return depositRepository.findByMemberIdAndAuctionId(memberId, request.auctionId())
-			.map(deposit -> new DepositHoldResponseDto(
+				.map(deposit -> {
+					if (deposit.getStatus() == DepositStatus.RELEASED) {
+						// 이미 환급된 경우: 다시 돈을 묶음 (재입찰)
+						return executeReHold(deposit, member, request.amount());
+					}
+					// 이미 HOLD 상태이거나 다른 처리 중인 경우: 기존 정보 반환
+					return new DepositHoldResponseDto(
+							deposit.getId(),
+							deposit.getAuctionId(),
+							deposit.getAmount(),
+							deposit.getStatus().name(),
+							deposit.getCreatedAt());
+				})
+				.orElseGet(() -> executeHold(member, request));
+	}
+
+	private DepositHoldResponseDto executeReHold(Deposit deposit, PaymentMember member, int amount) {
+		// 1. 지갑 잔액 확인 및 홀딩 (Wallet 업데이트)
+		Wallet wallet = paymentSupport.findWalletByMemberIdForUpdate(member.getId());
+		wallet.hold(amount);
+
+		// 2. Deposit 상태 변경
+		deposit.reHold(amount);
+
+		// 3. 이력 기록
+		PaymentTransaction transaction = PaymentTransaction.builder()
+				.member(member)
+				.wallet(wallet)
+				.transactionType(WalletTransactionType.DEPOSIT_HOLD)
+				.balanceDelta(0)
+				.holdingDelta(amount)
+				.balanceAfter(wallet.getBalance())
+				.referenceType(ReferenceType.DEPOSIT)
+				.referenceId(deposit.getId())
+				.build();
+		transactionRepository.save(transaction);
+
+		return new DepositHoldResponseDto(
 				deposit.getId(),
 				deposit.getAuctionId(),
 				deposit.getAmount(),
 				deposit.getStatus().name(),
-				deposit.getCreatedAt()
-			))
-			.orElseGet(() -> executeHold(member, request));
+				deposit.getCreatedAt());
 	}
 
 	private DepositHoldResponseDto executeHold(PaymentMember member, DepositHoldRequestDto request) {

--- a/payment-service/src/main/java/com/bugzero/rarego/app/PaymentHoldDepositUseCase.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/app/PaymentHoldDepositUseCase.java
@@ -25,6 +25,7 @@ public class PaymentHoldDepositUseCase {
 	private final PaymentTransactionRepository transactionRepository;
 	private final PaymentSupport paymentSupport;
 
+	@Transactional
 	public DepositHoldResponseDto holdDeposit(DepositHoldRequestDto request) {
 		// publicId → memberId 변환
 		PaymentMember member = paymentSupport.findMemberByPublicId(request.memberPublicId());

--- a/payment-service/src/main/java/com/bugzero/rarego/app/PaymentReleaseDepositUseCase.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/app/PaymentReleaseDepositUseCase.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.bugzero.rarego.domain.Deposit;
 import com.bugzero.rarego.domain.DepositStatus;
+import com.bugzero.rarego.domain.PaymentMember;
 import com.bugzero.rarego.domain.PaymentTransaction;
 import com.bugzero.rarego.domain.ReferenceType;
 import com.bugzero.rarego.domain.Wallet;
@@ -30,7 +31,6 @@ public class PaymentReleaseDepositUseCase {
 	private final PaymentSupport paymentSupport;
 	private final PaymentTransactionRepository transactionRepository;
 
-	@Transactional
 	public void releaseDeposits(Long auctionId, Long winnerId) {
 		List<Deposit> depositsToRelease = findDepositsToRelease(auctionId, winnerId);
 		if (depositsToRelease.isEmpty()) {
@@ -59,6 +59,28 @@ public class PaymentReleaseDepositUseCase {
 
 		transactionRepository.saveAll(transactions);
 		log.info("경매 {} 보증금 환급 완료: {}명", auctionId, depositsToRelease.size());
+	}
+
+	@Transactional
+	public void releaseDeposit(Long auctionId, String memberPublicId) {
+		PaymentMember member = paymentSupport.findMemberByPublicId(memberPublicId);
+		Deposit deposit = depositRepository.findByMemberIdAndAuctionId(member.getId(), auctionId)
+			.orElseThrow(() -> new CustomException(ErrorType.DEPOSIT_NOT_FOUND));
+
+		if (deposit.getStatus() != DepositStatus.HOLD) {
+			log.info("보증금이 HOLD 상태가 아님 (상태: {}), 환급 건너뜀", deposit.getStatus());
+			return;
+		}
+		Wallet wallet = paymentSupport.findWalletByMemberIdForUpdate(member.getId());
+
+		if (wallet == null) {
+			throw new CustomException(ErrorType.WALLET_NOT_FOUND);
+		}
+
+		PaymentTransaction transaction = releaseDeposit(deposit, wallet);
+		transactionRepository.save(transaction);
+
+		log.info("단건 보증금 환급 완료: auctionId={}, memberPublicId={}", auctionId, memberPublicId);
 	}
 
 	private List<Deposit> findDepositsToRelease(Long auctionId, Long winnerId) {

--- a/payment-service/src/main/java/com/bugzero/rarego/app/PaymentReleaseDepositUseCase.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/app/PaymentReleaseDepositUseCase.java
@@ -31,6 +31,7 @@ public class PaymentReleaseDepositUseCase {
 	private final PaymentSupport paymentSupport;
 	private final PaymentTransactionRepository transactionRepository;
 
+	@Transactional
 	public void releaseDeposits(Long auctionId, Long winnerId) {
 		List<Deposit> depositsToRelease = findDepositsToRelease(auctionId, winnerId);
 		if (depositsToRelease.isEmpty()) {
@@ -65,7 +66,7 @@ public class PaymentReleaseDepositUseCase {
 	public void releaseDeposit(Long auctionId, String memberPublicId) {
 		PaymentMember member = paymentSupport.findMemberByPublicId(memberPublicId);
 		Deposit deposit = depositRepository.findByMemberIdAndAuctionId(member.getId(), auctionId)
-			.orElseThrow(() -> new CustomException(ErrorType.DEPOSIT_NOT_FOUND));
+				.orElseThrow(() -> new CustomException(ErrorType.DEPOSIT_NOT_FOUND));
 
 		if (deposit.getStatus() != DepositStatus.HOLD) {
 			log.info("보증금이 HOLD 상태가 아님 (상태: {}), 환급 건너뜀", deposit.getStatus());

--- a/payment-service/src/main/java/com/bugzero/rarego/domain/Deposit.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/domain/Deposit.java
@@ -60,6 +60,14 @@ public class Deposit extends BaseIdAndTime {
 		this.status = DepositStatus.RELEASED;
 	}
 
+	public void reHold(int amount) {
+		if (this.status != DepositStatus.RELEASED) {
+			throw new CustomException(ErrorType.INVALID_DEPOSIT_STATUS);
+		}
+		this.amount = amount;
+		this.status = DepositStatus.HOLD;
+	}
+
 	public void use() {
 		if (this.status != DepositStatus.HOLD) {
 			throw new CustomException(ErrorType.ALREADY_USED_DEPOSIT);

--- a/payment-service/src/main/java/com/bugzero/rarego/in/InternalPaymentController.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/in/InternalPaymentController.java
@@ -30,6 +30,14 @@ public class InternalPaymentController {
 		return SuccessResponseDto.from(SuccessType.CREATED, paymentFacade.holdDeposit(request));
 	}
 
+	@Operation(summary = "보증금 단건 환급", description = "입찰 실패시 보증금을 환급합니다")
+	@PostMapping("/deposits/release/{auctionId}")
+	public SuccessResponseDto<Void> releaseDeposit(
+		@PathVariable Long auctionId,
+		@RequestParam String memberPublicId) {
+		paymentFacade.releaseDeposit(auctionId, memberPublicId);
+		return SuccessResponseDto.from(SuccessType.OK);
+	}
 	@Operation(summary = "환불 처리", description = "운영자가 결제 완료된 건을 환불 처리합니다")
 	@PostMapping("/refunds/{auctionId}")
 	public SuccessResponseDto<RefundResponseDto> processRefund(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #363 

## 🚀 작업 내용
- [x] RELEASED 상태인 보증금 기록이 있을 경우, 새로 생성하지 않고 다시 HOLD로 활성화하도록 수정
- [x] 경매 실패 시 개별 환불을 위한 releaseDeposit 단건 API 구현

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분