### PR TITLE
[FEAT/notification] 알림 삭제 로직 구현

### DIFF
--- a/notification-service/src/main/java/com/bugzero/rarego/NotificationApplication.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/NotificationApplication.java
@@ -2,7 +2,9 @@ package com.bugzero.rarego;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class NotificationApplication {
 

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCleanupUseCase.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationCleanupUseCase.java
@@ -1,0 +1,28 @@
+package com.bugzero.rarego.app;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bugzero.rarego.out.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationCleanupUseCase {
+	private final NotificationRepository notificationRepository;
+
+	@Transactional
+	public void deleteOldNotifications() {
+		// 30일 지난 알림
+		LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+
+		notificationRepository.deleteByCreatedAtBefore(threshold);
+
+		log.info("30일 지난 알림 삭제 완료");
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationFacade.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationFacade.java
@@ -10,7 +10,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import com.bugzero.rarego.global.response.PagedResponseDto;
 import com.bugzero.rarego.in.dto.NotificationResponseDto;
 import com.bugzero.rarego.in.dto.NotificationUnreadCountResponseDto;
-
 import com.bugzero.rarego.shared.member.domain.MemberDto;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +22,7 @@ public class NotificationFacade {
 	private final NotificationGetNotificationsUseCase notificationGetNotificationsUseCase;
 	private final NotificationGetUnreadCountUseCase notificationGetUnreadCountUseCase;
 	private final NotificationMarkAsReadUseCase notificationMarkAsReadUseCase;
+	private final NotificationCleanupUseCase notificationCleanupUseCase;
 	private final NotificationSubscribeUseCase notificationSubscribeUseCase;
 
 	public void createNotification(Object event) {
@@ -48,5 +48,9 @@ public class NotificationFacade {
 
 	public void syncMember(MemberDto memberDto) {
 		notificationSyncMemberUseCase.syncMember(memberDto);
+	}
+
+	public void deleteOldNotifications() {
+		notificationCleanupUseCase.deleteOldNotifications();
 	}
 }

--- a/notification-service/src/main/java/com/bugzero/rarego/app/NotificationSyncMemberUseCase.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/app/NotificationSyncMemberUseCase.java
@@ -13,12 +13,11 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class NotificationSyncMemberUseCase {
 	private final NotificationMemberRepository notificationMemberRepository;
 
+	@Transactional
 	public NotificationMember syncMember(MemberDto member) {
-
 		Optional<NotificationMember> existedOpt = notificationMemberRepository.findById(member.id());
 
 		/**

--- a/notification-service/src/main/java/com/bugzero/rarego/domain/Notification.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/domain/Notification.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -29,6 +30,13 @@ import lombok.NoArgsConstructor;
 			name = "uk_notification_dedup",
 			columnNames = {"reference_id", "type", "member_id"}
 		)
+	},
+	indexes = {
+		// 1. 회원 별 조회 & 정렬용
+		@Index(name = "idx_noti_member_id_desc", columnList = "member_id, id DESC"),
+
+		// 2. 삭제용
+		@Index(name = "idx_noti_created_at", columnList = "created_at")
 	}
 )
 public class Notification extends BaseIdAndTime {

--- a/notification-service/src/main/java/com/bugzero/rarego/in/NotificationCleanupScheduler.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/in/NotificationCleanupScheduler.java
@@ -1,0 +1,20 @@
+package com.bugzero.rarego.in;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.app.NotificationFacade;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationCleanupScheduler {
+	private final NotificationFacade notificationFacade;
+
+	// 매일 새벽 3시에 실행
+	@Scheduled(cron = "0 0 3 * * *")
+	public void runCleanUp() {
+		notificationFacade.deleteOldNotifications();
+	}
+}

--- a/notification-service/src/main/java/com/bugzero/rarego/in/NotificationConsumer.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/in/NotificationConsumer.java
@@ -1,10 +1,7 @@
 package com.bugzero.rarego.in;
 
-import static org.springframework.transaction.annotation.Propagation.*;
-
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.bugzero.rarego.app.NotificationFacade;
 import com.bugzero.rarego.shared.auction.event.AuctionEndedEvent;
@@ -82,7 +79,7 @@ public class NotificationConsumer {
 	 * notificationMember 생성 동기화
 	 */
 	@KafkaListener(topics = "member-joined")
-	public void handleMemberJoined(MemberJoinedEvent event) {
+	public void consumeMemberJoined(MemberJoinedEvent event) {
 		try {
 			notificationFacade.syncMember(event.memberDto());
 			log.info("[notification] 회원 레플리카 등록 완료 - memberPublicId: {}", event.memberDto().publicId());
@@ -97,7 +94,7 @@ public class NotificationConsumer {
 	 * @param event
 	 */
 	@KafkaListener(topics = "member-updated")
-	public void handleMemberUpdated(MemberUpdatedEvent event) {
+	public void consumeMemberUpdated(MemberUpdatedEvent event) {
 		try {
 			notificationFacade.syncMember(event.memberDto());
 			log.info("[notificaiton] 회원 레플리카 수정 완료 - memberPublicId: {}", event.memberDto().publicId());

--- a/notification-service/src/main/java/com/bugzero/rarego/out/NotificationRepository.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/out/NotificationRepository.java
@@ -1,8 +1,12 @@
 package com.bugzero.rarego.out;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.bugzero.rarego.domain.Notification;
 
@@ -12,4 +16,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	Page<Notification> findAllByMemberId(Long memberId, Pageable pageable);
 
 	long countAllByMemberIdAndIsReadFalse(Long id);
+
+	// 일괄 삭제 쿼리
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM Notification n WHERE n.createdAt < :threshold")
+	void deleteByCreatedAtBefore(LocalDateTime threshold);
 }

--- a/notification-service/src/test/java/com/bugzero/rarego/app/NotificationCleanupUseCaseTest.java
+++ b/notification-service/src/test/java/com/bugzero/rarego/app/NotificationCleanupUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.bugzero.rarego.app;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.BDDAssertions.within;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.bugzero.rarego.out.NotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCleanupUseCaseTest {
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@InjectMocks
+	private NotificationCleanupUseCase notificationCleanupUseCase;
+
+	@Test
+	@DisplayName("오래된 알림 삭제: 현재 시간 기준으로 30일 이전의 날짜를 계산하여 리포지토리를 호출한다.")
+	void deleteOldNotifications_success() {
+		// given
+		// 테스트 실행 시점의 30일 전 시간 계산 (예상값)
+		LocalDateTime expectedThreshold = LocalDateTime.now().minusDays(30);
+
+		// when
+		notificationCleanupUseCase.deleteOldNotifications();
+
+		// then
+		// 1. ArgumentCaptor를 사용하여 실제 메서드에 전달된 파라미터(날짜)를 낚아챕니다.
+		ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+
+		// 2. 리포지토리의 deleteByCreatedAtBefore 메서드가 정확히 1번 호출되었는지 검증하고, 파라미터를 캡처합니다.
+		then(notificationRepository).should(times(1))
+			.deleteByCreatedAtBefore(captor.capture());
+
+		// 3. 캡처한 날짜가 예상값(expectedThreshold)과 비슷한지 검증합니다.
+		// 테스트 실행 속도 차이를 고려하여 2초 정도의 오차는 허용합니다.
+		LocalDateTime actualThreshold = captor.getValue();
+
+		assertThat(actualThreshold).isCloseTo(expectedThreshold, within(2, ChronoUnit.SECONDS));
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #369 

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

<img width="1652" height="470" alt="image" src="https://github.com/user-attachments/assets/ae4b32de-8ed9-45dd-a201-1410253f6b2f" />
스케줄러 주기와 삭제 일을 임의로 수정해서 테스트 해봤습니다.

- [x] 매일 스케줄러로 30일 지난 알림을 일괄 삭제합니다.
- [x] 알림은 soft delete가 아닌 hard delete로 처리합니다.

## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
5분
