### PR TITLE
[FIX/product] 이미지 조회 URL 로직 수정

### DIFF
--- a/common/src/main/java/com/bugzero/rarego/global/util/S3Utils.java
+++ b/common/src/main/java/com/bugzero/rarego/global/util/S3Utils.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class S3Utils {
-	@Value("${aws.s3.bucket}")
+	@Value("${aws.s3.bucket:rarego-auction-product-images}")
 	private String bucketName;
 
 	@Value("${aws.region:ap-northeast-2}")

--- a/common/src/main/java/com/bugzero/rarego/global/util/S3Utils.java
+++ b/common/src/main/java/com/bugzero/rarego/global/util/S3Utils.java
@@ -1,0 +1,23 @@
+package com.bugzero.rarego.global.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class S3Utils {
+	@Value("${aws.s3.bucket}")
+	private String bucketName;
+
+	@Value("${aws.region:ap-northeast-2}")
+	private String region;
+
+	/**
+	 * S3 경로를 완전한 Public URL로 변환
+	 */
+	public String getPublicUrl(String s3Path) {
+		if (s3Path == null || s3Path.isBlank()) return null;
+		if (s3Path.startsWith("http")) return s3Path;
+
+		return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, s3Path);
+	}
+}

--- a/product-service/src/main/java/com/bugzero/rarego/product/app/ProductImageS3UseCase.java
+++ b/product-service/src/main/java/com/bugzero/rarego/product/app/ProductImageS3UseCase.java
@@ -37,7 +37,7 @@ public class ProductImageS3UseCase {
 	@Value("${aws.s3.expiration-minutes}")
 	private long expirationMinutes;
 
-	public PresignedUrlResponseDto createPresignerUrl(PresignedUrlRequestDto presignedUrlRequestDto) {
+	public PresignedUrlResponseDto createPresignedUrl(PresignedUrlRequestDto presignedUrlRequestDto) {
 		String uniqueFileName = createUniqueFileName(presignedUrlRequestDto.fileName());
 		String contentType = presignedUrlRequestDto.contentType();
 		String s3Path = "temp/" + uniqueFileName;

--- a/product-service/src/main/java/com/bugzero/rarego/product/app/ProductImageS3UseCase.java
+++ b/product-service/src/main/java/com/bugzero/rarego/product/app/ProductImageS3UseCase.java
@@ -67,29 +67,6 @@ public class ProductImageS3UseCase {
 			.build();
 	}
 
-	public String getPresignedGetUrl(String s3Path) {
-		if (s3Path == null || s3Path.isBlank())
-			return null;
-
-		// HTTP URL이 이미 포함되어 있다면 그대로 반환 (하위 호환성 유지용)
-		if (s3Path.startsWith("http"))
-			return s3Path;
-
-		software.amazon.awssdk.services.s3.model.GetObjectRequest getObjectRequest = software.amazon.awssdk.services.s3.model.GetObjectRequest
-				.builder()
-				.bucket(bucketName)
-				.key(s3Path)
-				.build();
-
-		software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest presignRequest = software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
-				.builder()
-				.signatureDuration(Duration.ofMinutes(expirationMinutes))
-				.getObjectRequest(getObjectRequest)
-				.build();
-
-		return s3Presigner.presignGetObject(presignRequest).url().toString();
-	}
-
 	public void confirmImages(List<String> tempPaths) {
 		for (String tempPath : tempPaths) {
 			try {
@@ -143,10 +120,13 @@ public class ProductImageS3UseCase {
 
 	// 파일명 앞에 UUID를 추가하여 고유한 파일명 생성 (DB 컬럼 길이를 고려하여 원본 파일명은 최대 100자로 제한)
 	private String createUniqueFileName(String fileName) {
-		String cleanName = fileName != null ? fileName : "image";
-		if (cleanName.length() > 100) {
-			cleanName = cleanName.substring(0, 100);
+		// 1. 확장자 추출 (예: .png, .jpg)
+		String extension = "";
+		if (fileName != null && fileName.contains(".")) {
+			extension = fileName.substring(fileName.lastIndexOf("."));
 		}
-		return UUID.randomUUID().toString() + "_" + cleanName;
+
+		// 2. UUID로만 구성된 파일명 생성 (예: 550e8400-e29b-41d4-a716-446655440000.png)
+		return UUID.randomUUID().toString() + extension;
 	}
 }

--- a/product-service/src/main/java/com/bugzero/rarego/product/app/ProductReadProductsForInspectionUseCase.java
+++ b/product-service/src/main/java/com/bugzero/rarego/product/app/ProductReadProductsForInspectionUseCase.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.bugzero.rarego.global.response.PagedResponseDto;
+import com.bugzero.rarego.global.util.S3Utils;
 import com.bugzero.rarego.product.domain.dto.ProductResponseForInspectionDto;
 import com.bugzero.rarego.product.domain.dto.ProductSearchForInspectionCondition;
 import com.bugzero.rarego.product.out.ProductRepository;
@@ -16,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ProductReadProductsForInspectionUseCase {
 	private final ProductRepository productRepository;
-	private final ProductImageS3UseCase s3PresignerUrlUseCase;
+	private final S3Utils s3Utils;
 
 	@Transactional(readOnly = true)
 	public PagedResponseDto<ProductResponseForInspectionDto> readProducts(
@@ -35,7 +36,7 @@ public class ProductReadProductsForInspectionUseCase {
 			dto.sellerEmail(),
 			dto.category(),
 			dto.inspectionStatus(),
-			s3PresignerUrlUseCase.getPresignedGetUrl(dto.thumbnail())
+			s3Utils.getPublicUrl(dto.thumbnail())
 		);
 	}
 }

--- a/product-service/src/main/java/com/bugzero/rarego/product/in/ProductImageController.java
+++ b/product-service/src/main/java/com/bugzero/rarego/product/in/ProductImageController.java
@@ -32,7 +32,7 @@ public class ProductImageController {
 		@Valid @RequestBody PresignedUrlRequestDto presignedUrlRequestDto
 	) {
 		return SuccessResponseDto.from(SuccessType.CREATED,
-			s3PresignerUrlUseCase.createPresignerUrl(presignedUrlRequestDto));
+			s3PresignerUrlUseCase.createPresignedUrl(presignedUrlRequestDto));
 	}
 
 }

--- a/product-service/src/test/java/com/bugzero/rarego/product/app/ProductImageS3UseCaseTest.java
+++ b/product-service/src/test/java/com/bugzero/rarego/product/app/ProductImageS3UseCaseTest.java
@@ -1,6 +1,7 @@
 package com.bugzero.rarego.product.app;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.net.URL;
@@ -21,6 +22,7 @@ import com.bugzero.rarego.product.domain.dto.PresignedUrlResponseDto;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -37,50 +39,96 @@ class ProductImageS3UseCaseTest {
 	@Mock
 	private S3Client s3Client;
 
+	private final String BUCKET_NAME = "rarego-bucket";
+
 	@BeforeEach
 	void setUp() {
-		ReflectionTestUtils.setField(useCase, "bucketName", "rarego-bucket");
+		ReflectionTestUtils.setField(useCase, "bucketName", BUCKET_NAME);
 		ReflectionTestUtils.setField(useCase, "expirationMinutes", 5L);
 	}
 
 	@Test
-	@DisplayName("DTO를 전달하면 고유한 경로와 Presigned URL이 포함된 응답을 반환한다.")
-	void createPresignerUrl_Success() throws Exception {
+	@DisplayName("성공: Presigned URL 발급 시 원본 파일명 대신 UUID 경로를 생성한다.")
+	void createPresignedUrl_Success() throws Exception {
 		// given
-		PresignedUrlRequestDto requestDto = new PresignedUrlRequestDto("lego_castle.png", "image/png");
-		String fakeUrl = "https://rarego-bucket.s3.amazonaws.com/products/unique-uuid_lego_castle.png";
+		String originalFileName = "lego_castle.png";
+		PresignedUrlRequestDto requestDto = new PresignedUrlRequestDto(originalFileName, "image/png");
+		String fakeUrl = "https://rarego-bucket.s3.amazonaws.com/temp/uuid-generated-name.png";
 
-		// S3에 권한요청할 때 필요한 PresignedUrl을 반환한다고 가정
 		PresignedPutObjectRequest mockResponse = mock(PresignedPutObjectRequest.class);
 		given(mockResponse.url()).willReturn(new URL(fakeUrl));
 		given(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).willReturn(mockResponse);
 
 		// when
-		PresignedUrlResponseDto result = useCase.createPresignerUrl(requestDto);
+		PresignedUrlResponseDto result = useCase.createPresignedUrl(requestDto);
 
 		// then
 		assertThat(result.url()).isEqualTo(fakeUrl);
 		assertThat(result.s3Path()).startsWith("temp/");
-		assertThat(result.s3Path()).contains("lego_castle.png");
+		assertThat(result.s3Path()).endsWith(".png"); // 확장자는 유지됨
+		assertThat(result.s3Path()).doesNotContain(originalFileName); // [중요] 원본 파일명은 포함되지 않음
 
 		verify(s3Presigner, times(1)).presignPutObject(any(PutObjectPresignRequest.class));
 	}
 
 	@Test
-	@DisplayName("비동기로 이미지 확정 로직(복사 및 삭제)이 수행된다.")
+	@DisplayName("성공: 이미지 확정 시 temp에서 products로 복사 후 기존 파일을 삭제한다.")
 	void confirmImages_Success() {
 		// given
 		List<String> tempPaths = List.of("temp/image1.png", "temp/image2.png");
-
-		// s3Client의 동작은 void이거나 영향이 없으므로 기본 Mock 동작(doNothing)을 따름
-		// (Mockito는 기본적으로 void 메서드에 대해 아무 일도 하지 않음)
 
 		// when
 		useCase.confirmImages(tempPaths);
 
 		// then
-		// 각 이미지당 copy와 delete가 한 번씩 호출되었는지 검증
 		verify(s3Client, times(2)).copyObject(any(CopyObjectRequest.class));
 		verify(s3Client, times(2)).deleteObject(any(DeleteObjectRequest.class));
+	}
+
+	@Test
+	@DisplayName("예외: 이미지 확정 중 S3 에러가 발생해도 로그를 남기고 다음 파일 처리를 계속한다.")
+	void confirmImages_HandleException() {
+		// given
+		List<String> tempPaths = List.of("temp/fail.png", "temp/success.png");
+
+		// 첫 번째 호출에서만 예외 발생 설정
+		given(s3Client.copyObject(any(CopyObjectRequest.class)))
+			.willThrow(new RuntimeException("S3 Connection Fail")) // 첫 번째 파일 에러
+			.willReturn(null); // 두 번째 파일은 정상 처리
+
+		// when
+		useCase.confirmImages(tempPaths);
+
+		// then
+		// 에러가 나더라도 전체 루프는 돌기 때문에 copyObject는 총 2번 호출되어야 함
+		verify(s3Client, times(2)).copyObject(any(CopyObjectRequest.class));
+		// 에러가 발생한 첫 번째 파일은 삭제 로직이 호출되지 않으므로 delete는 1번만 호출됨
+		verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+	}
+
+	@Test
+	@DisplayName("성공: 이미지 일괄 삭제 요청 시 S3 SDK를 정상 호출한다.")
+	void deleteS3Image_Success() {
+		// given
+		List<String> s3Paths = List.of("products/img1.png", "products/img2.png");
+
+		// when
+		useCase.deleteS3Image(s3Paths);
+
+		// then
+		verify(s3Client, times(1)).deleteObjects(any(DeleteObjectsRequest.class));
+	}
+
+	@Test
+	@DisplayName("예외: 이미지 삭제 중 예외 발생 시 로그를 남기고 종료한다.")
+	void deleteS3Image_HandleException() {
+		// given
+		List<String> s3Paths = List.of("products/img1.png");
+		given(s3Client.deleteObjects(any(DeleteObjectsRequest.class)))
+			.willThrow(new RuntimeException("Delete Error"));
+
+		// when & then: 내부에서 catch하므로 예외가 밖으로 던져지지는 않음
+		assertDoesNotThrow(() -> useCase.deleteS3Image(s3Paths));
+		verify(s3Client, times(1)).deleteObjects(any(DeleteObjectsRequest.class));
 	}
 }

--- a/product-service/src/test/java/com/bugzero/rarego/product/app/ProductImageS3UseCaseTest.java
+++ b/product-service/src/test/java/com/bugzero/rarego/product/app/ProductImageS3UseCaseTest.java
@@ -67,20 +67,6 @@ class ProductImageS3UseCaseTest {
 	}
 
 	@Test
-	@DisplayName("S3 경로가 이미 HTTP URL 형태라면 그대로 반환한다.")
-	void getPresignedGetUrl_ReturnOriginal_WhenAlreadyUrl() {
-		// given
-		String s3Path = "http://already-url.com/image.png";
-
-		// when
-		String resultUrl = useCase.getPresignedGetUrl(s3Path);
-
-		// then
-		assertThat(resultUrl).isEqualTo(s3Path);
-		verifyNoInteractions(s3Presigner); // S3Presigner를 호출하지 않아야 함
-	}
-
-	@Test
 	@DisplayName("비동기로 이미지 확정 로직(복사 및 삭제)이 수행된다.")
 	void confirmImages_Success() {
 		// given


### PR DESCRIPTION
# 🐛 버그 수정 PR

## #️⃣ 연관된 이슈
close: #488 

## 📝 수정 요약
<!-- 먼저 버그에 대한 간단한 설명을 적어주세요 -->

- 🚨 문제점
  - S3 이미지 조회 실패: 특정 이미지(한글명, 공백 포함) 조회 시 getPresignedUrl 메서드를 통하지 않으면 S3 서버에서 Access Denied 에러를 반환하며 이미지가 렌더링되지 않는 현상이 발생했습니다.
  - 기존 이미지를 조회할 때 사용하던 getPresignedUrl은 AWS S3 라이브러리가 있어야 사용이 가능합니다. 
    - 경매 모듈에서 경매 정보 상세 조회시 이미지를 조회해야 하는데 경매모듈에는  AWS S3 라이브러리가 주입되어 있지 않습니다. 
- 🔍 원인 분석
  - 강한 결합도: 서비스 로직이 특정 인프라 기술(AWS SDK)에 직접 의존하고 있어, 테스트가 까다롭고 멀티 모듈 환경에서 의존성 전파 문제가 있었습니다
  - 인코딩 불일치: 파일명에 포함된 한글 및 특수문자가 브라우저와 S3 간에 서로 다르게 인코딩되어 객체 참조에 실패했습니다.
- 💡 해결 방법
  - 파일명 정규화: 파일 업로드 시 원본 명칭을 배제하고 UUID.확장자 포맷으로 통일하여 인코딩 이슈를 근본적으로 차단했습니다.
  - 의존성 분리 및 공통화
    -  조회 로직에서 AWS SDK 의존성을 제거하고 common 모듈에 가벼운 S3Utils 컴포넌트를 구현했습니다.
- 성능 최적화: 시그니처 계산이 없는 고정 URL(Public URL) 방식을 채택하여 조회 속도를 높이고 브라우저 캐싱 효율을 극대화했습니다.

## 🛠️ PR 유형
- [X] 버그 수정
- [ ] 테스트 리팩토링
- [ ] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)
이미지 조회 기능이 필요할 때 DB에 저장된 url 를 가져오고 나서 S3Utils.getPublicUrl(DB에 저장된 url) 로 변환해주면 됩니다. 
## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션을 지켰습니다.
- [X] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
5분