### PR TITLE
[FIX/auth] 회원 탈퇴 이후 로그인 오류 처리

### DIFF
--- a/auth-service/src/main/java/com/bugzero/rarego/app/AuthOAuth2AccountService.java
+++ b/auth-service/src/main/java/com/bugzero/rarego/app/AuthOAuth2AccountService.java
@@ -7,6 +7,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -15,6 +16,8 @@ import org.springframework.stereotype.Service;
 import com.bugzero.rarego.domain.AccountDto;
 import com.bugzero.rarego.domain.OAuth2AttributeMapper;
 import com.bugzero.rarego.domain.TokenPairDto;
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,14 +40,29 @@ public class AuthOAuth2AccountService implements OAuth2UserService<OAuth2UserReq
 			.getUserInfoEndpoint()
 			.getUserNameAttributeName();
 
-		AccountDto accountDto = OAuth2AttributeMapper.toAccountDto(
-			registrationId, userNameAttributeName, oauth2User.getAttributes());
-		TokenPairDto tokenPair = authFacade.login(accountDto.providerId(), accountDto.email(), accountDto.provider());
+		AccountDto accountDto;
+		TokenPairDto tokenPair;
+		try {
+			accountDto = OAuth2AttributeMapper.toAccountDto(
+				registrationId, userNameAttributeName, oauth2User.getAttributes());
+			tokenPair = authFacade.login(accountDto.providerId(), accountDto.email(), accountDto.provider());
+		} catch (CustomException e) {
+			throw toOAuth2AuthenticationException(e);
+		}
 
 		Map<String, Object> attributes = new HashMap<>(oauth2User.getAttributes());
 		attributes.put(ACCESS_TOKEN_ATTRIBUTE, tokenPair.accessToken());
 		attributes.put(REFRESH_TOKEN_ATTRIBUTE, tokenPair.refreshToken());
 
 		return new DefaultOAuth2User(oauth2User.getAuthorities(), attributes, userNameAttributeName);
+	}
+
+	private OAuth2AuthenticationException toOAuth2AuthenticationException(CustomException e) {
+		ErrorType errorType = e.getErrorType();
+		String message = e.getMessage() == null || e.getMessage().isBlank()
+			? errorType.getMessage()
+			: e.getMessage();
+		OAuth2Error oauth2Error = new OAuth2Error(String.valueOf(errorType.getCode()), message, null);
+		return new OAuth2AuthenticationException(oauth2Error, message, e);
 	}
 }

--- a/auth-service/src/main/java/com/bugzero/rarego/config/AuthOAuth2SecurityConfigurer.java
+++ b/auth-service/src/main/java/com/bugzero/rarego/config/AuthOAuth2SecurityConfigurer.java
@@ -4,6 +4,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.stereotype.Component;
 
 import com.bugzero.rarego.app.AuthOAuth2AccountService;
+import com.bugzero.rarego.security.CustomOAuth2FailureHandler;
 import com.bugzero.rarego.security.CustomOAuth2SuccessHandler;
 import com.bugzero.rarego.global.security.OAuth2SecurityConfigurer;
 
@@ -14,12 +15,14 @@ import lombok.RequiredArgsConstructor;
 public class AuthOAuth2SecurityConfigurer implements OAuth2SecurityConfigurer {
 	private final AuthOAuth2AccountService authOAuth2AccountService;
 	private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+	private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
 
 	@Override
 	public void configure(HttpSecurity http) throws Exception {
 		http.oauth2Login(oauth2 -> oauth2
 			.userInfoEndpoint(userInfo -> userInfo.userService(authOAuth2AccountService))
 			.successHandler(customOAuth2SuccessHandler)
+			.failureHandler(customOAuth2FailureHandler)
 		);
 	}
 }

--- a/auth-service/src/main/java/com/bugzero/rarego/security/CustomOAuth2FailureHandler.java
+++ b/auth-service/src/main/java/com/bugzero/rarego/security/CustomOAuth2FailureHandler.java
@@ -28,7 +28,7 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
 		ErrorType errorType = resolveErrorType(exception);
 		String errorMessage = resolveErrorMessage(exception, errorType);
 
-		String targetUrl = UriComponentsBuilder.fromUriString(frontUrl + "/auth/login")
+		String targetUrl = UriComponentsBuilder.fromUriString(frontUrl + "/login")
 			.queryParam("errorCode", errorType.getCode())
 			.queryParam("errorMessage", errorMessage)
 			.build()

--- a/auth-service/src/main/java/com/bugzero/rarego/security/CustomOAuth2FailureHandler.java
+++ b/auth-service/src/main/java/com/bugzero/rarego/security/CustomOAuth2FailureHandler.java
@@ -1,0 +1,85 @@
+package com.bugzero.rarego.security;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.bugzero.rarego.global.exception.CustomException;
+import com.bugzero.rarego.global.response.ErrorType;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler {
+	@Value("${custom.global.frontUrl}")
+	private String frontUrl;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+		ErrorType errorType = resolveErrorType(exception);
+		String errorMessage = resolveErrorMessage(exception, errorType);
+
+		String targetUrl = UriComponentsBuilder.fromUriString(frontUrl + "/auth/callback")
+			.queryParam("errorCode", errorType.getCode())
+			.queryParam("errorMessage", errorMessage)
+			.build().toUriString();
+
+		response.sendRedirect(targetUrl);
+	}
+
+	private ErrorType resolveErrorType(AuthenticationException exception) {
+		if (exception instanceof OAuth2AuthenticationException oauthException) {
+			OAuth2Error error = oauthException.getError();
+			ErrorType fromError = resolveErrorTypeFromOAuth2Error(error);
+			if (fromError != null) {
+				return fromError;
+			}
+		}
+		if (exception.getCause() instanceof CustomException customException) {
+			return customException.getErrorType();
+		}
+		return ErrorType.AUTH_OAUTH2_INVALID_RESPONSE;
+	}
+
+	private ErrorType resolveErrorTypeFromOAuth2Error(OAuth2Error error) {
+		if (error == null || error.getErrorCode() == null) {
+			return null;
+		}
+		String code = error.getErrorCode();
+		try {
+			int numericCode = Integer.parseInt(code);
+			return ErrorType.findByCode(numericCode).orElse(null);
+		} catch (NumberFormatException ignored) {
+			// fall through
+		}
+		try {
+			return ErrorType.valueOf(code);
+		} catch (IllegalArgumentException ignored) {
+			return null;
+		}
+	}
+
+	private String resolveErrorMessage(AuthenticationException exception, ErrorType errorType) {
+		if (exception instanceof OAuth2AuthenticationException oauthException) {
+			OAuth2Error error = oauthException.getError();
+			if (error != null && error.getDescription() != null && !error.getDescription().isBlank()) {
+				return error.getDescription();
+			}
+		}
+		if (exception.getCause() instanceof CustomException customException) {
+			String message = customException.getMessage();
+			if (message != null && !message.isBlank()) {
+				return message;
+			}
+		}
+		return errorType.getMessage();
+	}
+}

--- a/auth-service/src/main/java/com/bugzero/rarego/security/CustomOAuth2FailureHandler.java
+++ b/auth-service/src/main/java/com/bugzero/rarego/security/CustomOAuth2FailureHandler.java
@@ -9,6 +9,7 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
+import java.nio.charset.StandardCharsets;
 
 import com.bugzero.rarego.global.exception.CustomException;
 import com.bugzero.rarego.global.response.ErrorType;
@@ -27,10 +28,12 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
 		ErrorType errorType = resolveErrorType(exception);
 		String errorMessage = resolveErrorMessage(exception, errorType);
 
-		String targetUrl = UriComponentsBuilder.fromUriString(frontUrl + "/auth/callback")
+		String targetUrl = UriComponentsBuilder.fromUriString(frontUrl + "/auth/login")
 			.queryParam("errorCode", errorType.getCode())
 			.queryParam("errorMessage", errorMessage)
-			.build().toUriString();
+			.build()
+			.encode(StandardCharsets.UTF_8)
+			.toUriString();
 
 		response.sendRedirect(targetUrl);
 	}
@@ -58,7 +61,7 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
 			int numericCode = Integer.parseInt(code);
 			return ErrorType.findByCode(numericCode).orElse(null);
 		} catch (NumberFormatException ignored) {
-			// fall through
+			// code가 숫자 포맷이 아니면 enum 이름으로 파싱 시도
 		}
 		try {
 			return ErrorType.valueOf(code);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #491 

## 🚀 작업 내용
<img width="1383" height="692" alt="스크린샷 2026-02-23 오후 3 57 45" src="https://github.com/user-attachments/assets/b525e045-c52b-43f7-b870-ee27458f37b3" />



- [x] 기존: Oauth2 login 오류시 Whitelabel Error Page This application has no explicit mapping for /error, so you are seeing this as a fallback.
현재: **리다이렉트 param으로**  `errorCode, errorMessage`넣어서 프런트가 토스트 메세지 설정 후 param을 지워서 로그인 페이지로 갈 수 있도록 함
`http://{front_url}/login?errorCode=1514&errorMessage=탈퇴한%20계정입니다.`

- [x] 프런트의 경우 
	•	useSearchParams()로 errorCode 읽기
	•	toast.error(...) 등으로 에러메세지 팝업 표시
	•	표시 후 router.replace()로 query 지우기

## 🔍 리뷰 요청 사항 및 공유자료
탈퇴한 사용자에 대해 에러 코드가 반환되는지 확인 부탁드립니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
5분 + 

