### PR TITLE
[FIX/common] DLT 컨슈머 도메인 격리

### DIFF
--- a/auction-service/src/main/java/com/bugzero/rarego/in/AuctionDLTConsumer.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/in/AuctionDLTConsumer.java
@@ -1,0 +1,26 @@
+package com.bugzero.rarego.in;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.global.kafka.AbstractDLTConsumer;
+
+@Component
+public class AuctionDLTConsumer extends AbstractDLTConsumer {
+
+	@KafkaListener(
+		// SpEL을 활용해 본인 서비스명이 포함된 모든 DLT 토픽을 구독합니다.
+		topicPattern = ".*\\." + "${spring.application.name}" + "\\.DLT",
+		groupId = "${spring.application.name}-dlt-group",
+		containerFactory = "dltContainerFactory"
+	)
+	public void onMessage(ConsumerRecord<String, String> record) {
+		super.process(record); // 부모 클래스의 공통 로깅 실행
+	}
+
+	@Override
+	protected void handleCustomLogic(String topic, String error, String payload) {
+		// 필요하다면 여기서 전용 슬랙 알림이나 DB 복구 로직 수행
+	}
+}

--- a/common/src/main/java/com/bugzero/rarego/global/config/KafkaConfig.java
+++ b/common/src/main/java/com/bugzero/rarego/global/config/KafkaConfig.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -56,9 +57,14 @@ public class KafkaConfig {
 	// [중요] DLT 발행을 위한 Recoverer 설정
 	@Bean
 	public DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(KafkaTemplate<String, Object> kafkaTemplate) {
-		// 실패 시 "원본토픽명.DLT"로 메시지를 전송합니다.
-		// 이때 전송 실패 원인(Exception) 정보가 헤더에 자동으로 포함됩니다.
-		return new DeadLetterPublishingRecoverer(kafkaTemplate);
+		// 원본 레코드와 예외 정보를 바탕으로 목적지 토픽을 결정합니다.
+		return new DeadLetterPublishingRecoverer(kafkaTemplate, (record, exception) -> {
+			// 결과 예시: auction-info-management.auction-service.DLT
+			String dltTopicName = record.topic() + "." + applicationName + ".DLT";
+			log.info("[DLT 발행] 원본 토픽: {}, 목적지 DLT: {}", record.topic(), dltTopicName);
+
+			return new TopicPartition(dltTopicName, -1); // -1은 특정 파티션을 지정하지 않음을 의미
+		});
 	}
 
 	// [중요] 중앙 집중식 에러 핸들러 (Retry + DLT)

--- a/common/src/main/java/com/bugzero/rarego/global/kafka/AbstractDLTConsumer.java
+++ b/common/src/main/java/com/bugzero/rarego/global/kafka/AbstractDLTConsumer.java
@@ -5,47 +5,44 @@ import java.nio.charset.StandardCharsets;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Component
-public class DLTConsumer {
+public abstract class AbstractDLTConsumer {
 
 	@Value("${spring.application.name}")
 	private String applicationName;
 
 	/**
-	 * 특정 도메인에 종속되지 않고, .DLT로 끝나는 모든 토픽을 구독합니다.
+	 * 공통 실행 메서드: 각 서비스 리스너가 호출할 대상입니다.
 	 */
-	@KafkaListener(
-		topicPattern = ".*[.-](?i)dlt",
-		groupId = "${spring.application.name}-global-dlt-group",
-		// [핵심] 에러 핸들러가 없는 전용 팩토리를 사용하도록 명시합니다.
-		containerFactory = "dltContainerFactory"
-	)
-	public void processDlt(ConsumerRecord<String, String> record) {
+	protected void process(ConsumerRecord<String, String> record) {
 		try {
-			log.error("============= [Global DLT Monitor] =============");
+			log.error("============= [Global DLT Monitor - {}] =============", applicationName.toUpperCase());
 
-			// 로그에서 확인된 실제 키값을 직접 매핑합니다.
+			// 우리가 확인한 실제 헤더 키값 적용
 			String originalTopic = getHeaderValue(record, "kafka_dlt-original-topic");
 			String errorMessage = getHeaderValue(record, "kafka_dlt-exception-message");
 			String messageId = getHeaderValue(record, "messageId");
 
-			log.error("발생 서비스: {}", applicationName);
 			log.error("원본 토픽: {}", originalTopic);
 			log.error("메시지 ID: {}", messageId);
 			log.error("에러 내용: {}", errorMessage);
 			log.error("데이터: {}", record.value());
-			log.error("===============================================");
+			log.error("====================================================");
 
-			// TODO: Slack 알림 시 errorMessage의 앞부분만 잘라서 보내면 깔끔합니다.
+			// 추가 로직(슬랙 알림 등)이 필요한 경우 하위 클래스에서 처리하도록 훅을 제공합니다.
+			handleCustomLogic(originalTopic, errorMessage, record.value());
+
 		} catch (Exception e) {
-			log.error("DLT 로깅 중 에러 발생: {}", e.getMessage());
+			log.error("DLT 로깅 처리 중 예외 발생: {}", e.getMessage());
 		}
+	}
+
+	// 하위 클래스에서 선택적으로 오버라이딩 (예: 슬랙 알림 전송)
+	protected void handleCustomLogic(String topic, String error, String payload) {
+		// 기본값은 빈 로직
 	}
 
 	private String getHeaderValue(ConsumerRecord<?, ?> record, String headerKey) {

--- a/notification-service/src/main/java/com/bugzero/rarego/in/NotificationDLTConsumer.java
+++ b/notification-service/src/main/java/com/bugzero/rarego/in/NotificationDLTConsumer.java
@@ -1,0 +1,26 @@
+package com.bugzero.rarego.in;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.global.kafka.AbstractDLTConsumer;
+
+@Component
+public class NotificationDLTConsumer extends AbstractDLTConsumer {
+
+	@KafkaListener(
+		// SpEL을 활용해 본인 서비스명이 포함된 모든 DLT 토픽을 구독합니다.
+		topicPattern = ".*\\." + "${spring.application.name}" + "\\.DLT",
+		groupId = "${spring.application.name}-dlt-group",
+		containerFactory = "dltContainerFactory"
+	)
+	public void onMessage(ConsumerRecord<String, String> record) {
+		super.process(record); // 부모 클래스의 공통 로깅 실행
+	}
+
+	@Override
+	protected void handleCustomLogic(String topic, String error, String payload) {
+		// 필요하다면 여기서 전용 슬랙 알림이나 DB 복구 로직 수행
+	}
+}

--- a/payment-service/src/main/java/com/bugzero/rarego/in/PaymentDLTConsumer.java
+++ b/payment-service/src/main/java/com/bugzero/rarego/in/PaymentDLTConsumer.java
@@ -1,0 +1,26 @@
+package com.bugzero.rarego.in;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.global.kafka.AbstractDLTConsumer;
+
+@Component
+public class PaymentDLTConsumer extends AbstractDLTConsumer {
+
+	@KafkaListener(
+		// SpEL을 활용해 본인 서비스명이 포함된 모든 DLT 토픽을 구독합니다.
+		topicPattern = ".*\\." + "${spring.application.name}" + "\\.DLT",
+		groupId = "${spring.application.name}-dlt-group",
+		containerFactory = "dltContainerFactory"
+	)
+	public void onMessage(ConsumerRecord<String, String> record) {
+		super.process(record); // 부모 클래스의 공통 로깅 실행
+	}
+
+	@Override
+	protected void handleCustomLogic(String topic, String error, String payload) {
+		// 필요하다면 여기서 전용 슬랙 알림이나 DB 복구 로직 수행
+	}
+}

--- a/product-service/src/main/java/com/bugzero/rarego/product/in/ProductDLTConsumer.java
+++ b/product-service/src/main/java/com/bugzero/rarego/product/in/ProductDLTConsumer.java
@@ -1,0 +1,26 @@
+package com.bugzero.rarego.product.in;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.bugzero.rarego.global.kafka.AbstractDLTConsumer;
+
+@Component
+public class ProductDLTConsumer extends AbstractDLTConsumer {
+
+	@KafkaListener(
+		// SpEL을 활용해 본인 서비스명이 포함된 모든 DLT 토픽을 구독합니다.
+		topicPattern = ".*\\." + "${spring.application.name}" + "\\.DLT",
+		groupId = "${spring.application.name}-dlt-group",
+		containerFactory = "dltContainerFactory"
+	)
+	public void onMessage(ConsumerRecord<String, String> record) {
+		super.process(record); // 부모 클래스의 공통 로깅 실행
+	}
+
+	@Override
+	protected void handleCustomLogic(String topic, String error, String payload) {
+		// 필요하다면 여기서 전용 슬랙 알림이나 DB 복구 로직 수행
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #484

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

- 물리적 도메인 격리
  - DeadLetterPublishingRecoverer에서 DLT 메시지 적재시 토픽명을 원본토픽.서비스명.DLT로 동적 생성하도록 설정하였습니다. 
    - 이를 통해 여러 모듈이 같은 토픽(member-joined 등)을 구독하고 해당 로직 수행 시 예외가 발생하는 경우 장애 메시지가 서비스별로 분리되어 적재됩니다. 
  - 도메인 별 DLTConsumer에서 topicPattern을 통해 오직 자신의 서비스명이 포함된 DLT 토픽만 선택적으로 수신함으로써 타 도메인과의 간섭을 완전히 제거했습니다.
- 유연한 확장성 
  - AbstractDLTConsumer라는 추상 클래스를 통해 공통 로깅은 한곳에서 관리하고, handleCustomLogic을 제공하여 향후 전용 슬랙 알림이나 복구 로직을 서비스별로 오버라이딩을 통해 손쉽게 추가할 수 있게 설계했습니다.
  
## 🔍 리뷰 요청 사항 및 공유자료
<!-- 리뷰어에게 확인받고 싶은 내용을 적어주세요 -->
- AuctionConsumer에서 발생한 DLT 메세지는 `토픽명.auction-service.DLT` 에만 적재된 후 `auction-service-dlt` 컨슈머에서만 처리되는 것을 확인했습니다
<img width="2019" height="63" alt="image" src="https://github.com/user-attachments/assets/4f9aa9e8-cc7a-4a8a-bfd1-7d78cc04c709" />
<img width="977" height="443" alt="image" src="https://github.com/user-attachments/assets/7ef788b7-a0cd-47ce-a769-a0733694eacf" />
<img width="1745" height="214" alt="image" src="https://github.com/user-attachments/assets/0e8f68cc-4745-43e0-8ef0-56d791f9186a" />


## ✅ PR Checklist
- [X] 커밋 메시지 컨벤션을 지켰습니다.
- [X] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
<!-- 5분, 10분 등등... -->
10분
---

