### PR TITLE
[FIX/product] ES 이미지 조회 통일되게 변경 + ES 이미지 리스트로 변경

### DIFF
--- a/auction-service/src/main/java/com/bugzero/rarego/app/AuctionReadUseCase.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/app/AuctionReadUseCase.java
@@ -385,7 +385,7 @@ public class AuctionReadUseCase {
     }
 
     private Pageable applySorting(Pageable pageable, AuctionSortType sortType) {
-        Sort sort = (sortType != null) ? sortType.getSort() : Sort.unsorted();
+        Sort sort = (sortType != null) ? sortType.getSort() : AuctionSortType.NEWEST.getSort();
         return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
     }
 }

--- a/auction-service/src/main/java/com/bugzero/rarego/in/dto/es/ProductSearchDocumentDto.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/in/dto/es/ProductSearchDocumentDto.java
@@ -1,16 +1,12 @@
 package com.bugzero.rarego.in.dto.es;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record ProductSearchDocumentDto (
+public record ProductSearchDocumentDto(
 
 	String id,
 
@@ -23,8 +19,8 @@ public record ProductSearchDocumentDto (
 	@JsonProperty("description")
 	String description,
 
-	@JsonProperty("imageUrl")
-	String imageUrl,
+	@JsonProperty("imageUrls")
+	List<String> imageUrls,
 
 	@JsonProperty("startPrice")
 	int startPrice,

--- a/auction-service/src/main/java/com/bugzero/rarego/out/es/ProductSearchClient.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/out/es/ProductSearchClient.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import com.bugzero.rarego.global.util.S3Utils;
 import com.bugzero.rarego.in.dto.es.ProductSearchDocumentDto;
 import com.bugzero.rarego.shared.product.dto.ProductAuctionResponseDto;
 import com.bugzero.rarego.shared.product.type.Category;
@@ -35,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ProductSearchClient {
 
     private final ElasticsearchClient elasticsearchClient;
+    private final S3Utils s3Utils;
     private static final String INDEX_NAME = "product_search";
 
     // Temporary mitigation for expensive approved-id full scan
@@ -224,7 +226,10 @@ public class ProductSearchClient {
     }
 
     private ProductAuctionResponseDto convertToDto(ProductSearchDocumentDto doc) {
-        String imageUrl = doc.imageUrl() != null ? doc.imageUrl() : "";
+        List<String> imageUrls = (doc.imageUrls() != null && !doc.imageUrls().isEmpty())
+            ? doc.imageUrls().stream().map(s3Utils::getPublicUrl).toList()
+            : List.of();
+        String thumbnailUrl = imageUrls.isEmpty() ? "" : imageUrls.get(0);
 
         return ProductAuctionResponseDto.builder()
             .id(doc.productId())
@@ -232,8 +237,8 @@ public class ProductSearchClient {
             .name(doc.productName())
             .description(doc.description())
             .category(doc.category())
-            .thumbnailUrl(imageUrl)
-            .imageUrls(List.of(imageUrl))
+            .thumbnailUrl(thumbnailUrl)
+            .imageUrls(imageUrls)
             .build();
     }
 }

--- a/auction-service/src/main/java/com/bugzero/rarego/out/es/ProductSearchClient.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/out/es/ProductSearchClient.java
@@ -227,7 +227,7 @@ public class ProductSearchClient {
 
     private ProductAuctionResponseDto convertToDto(ProductSearchDocumentDto doc) {
         List<String> imageUrls = (doc.imageUrls() != null && !doc.imageUrls().isEmpty())
-            ? doc.imageUrls().stream().map(s3Utils::getPublicUrl).toList()
+            ? doc.imageUrls().stream().map(s3Utils::getPublicUrl).filter(Objects::nonNull).toList()
             : List.of();
         String thumbnailUrl = imageUrls.isEmpty() ? "" : imageUrls.get(0);
 

--- a/common/src/main/java/com/bugzero/rarego/shared/auction/dto/AuctionSortType.java
+++ b/common/src/main/java/com/bugzero/rarego/shared/auction/dto/AuctionSortType.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuctionSortType {
 	CLOSING_SOON("마감임박순", Sort.by(Sort.Direction.ASC, "endTime")),
-	NEWEST("최신순", Sort.by(Sort.Direction.DESC, "createdAt"));
+	NEWEST("최신순", Sort.by(Sort.Direction.DESC, "id"));
 
 
 	private final String description;

--- a/product-service/src/main/java/com/bugzero/rarego/ai/app/AiGetInternalPriceUseCase.java
+++ b/product-service/src/main/java/com/bugzero/rarego/ai/app/AiGetInternalPriceUseCase.java
@@ -31,7 +31,6 @@ public class AiGetInternalPriceUseCase {
 	//가져올 유사상품 최대갯수
 	private static final int LIST_LIMIT = 3;
 
-
 	public List<AiInternalPriceResponseDto> findTopSimilarProducts(
 		AiInternalPriceRequestDto dto) {
 		String searchQuery = String.format(ProductSearchDocument.EMBEDDING_TEMPLATE,
@@ -66,7 +65,7 @@ public class AiGetInternalPriceUseCase {
 					doc.getFinalPrice(),
 					doc.getStartedAt(),
 					doc.getClosedAt(),
-					doc.getImageUrl(),
+					doc.getImageUrls(),
 					hit.getScore() // ES에서 계산된 유사도 점수
 				);
 			})

--- a/product-service/src/main/java/com/bugzero/rarego/ai/domain/dto/AiInternalPriceResponseDto.java
+++ b/product-service/src/main/java/com/bugzero/rarego/ai/domain/dto/AiInternalPriceResponseDto.java
@@ -1,6 +1,7 @@
 package com.bugzero.rarego.ai.domain.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.bugzero.rarego.shared.product.type.Category;
 import com.bugzero.rarego.shared.product.type.ProductCondition;
@@ -16,7 +17,7 @@ public record AiInternalPriceResponseDto(
 	int finalPrice,
 	LocalDateTime startedAt,
 	LocalDateTime closedAt,
-	String thumbnail,
-	double score
+	List<String> imageUrls,
+	float score
 ) {
 }

--- a/product-service/src/main/java/com/bugzero/rarego/product/app/ProductSearchService.java
+++ b/product-service/src/main/java/com/bugzero/rarego/product/app/ProductSearchService.java
@@ -105,12 +105,11 @@ public class ProductSearchService {
 		// 임베딩 벡터 생성
 		List<Float> vector = generateEmbeddingSafe(textToEmbed);
 
-		// 이미지 정렬 및 선택
-		String imageUrl = (images != null && !images.isEmpty()) ? images.stream()
+		// 이미지 정렬 후 전체 URL 수집
+		List<String> imageUrls = (images != null && !images.isEmpty()) ? images.stream()
 			.sorted(Comparator.comparingInt(ProductImage::getSortOrder))
 			.map(ProductImage::getImageUrl)
-			.findFirst()
-			.orElse(null) : null;
+			.toList() : List.of();
 
 		return ProductSearchDocument.builder()
 			.id(docId)
@@ -120,7 +119,7 @@ public class ProductSearchService {
 			.productCondition(product.getProductCondition())
 			.category(product.getCategory())
 			.sellerId(product.getSeller().getId())
-			.imageUrl(imageUrl)
+			.imageUrls(imageUrls)
 			.embedding(vector)
 			.auctionId(auctionId)
 			.startPrice(startPrice)
@@ -158,7 +157,7 @@ public class ProductSearchService {
 			.startedAt(doc.getStartedAt())
 			.closedAt(LocalDateTime.now())
 			.sellerId(doc.getSellerId())
-			.imageUrl(doc.getImageUrl())
+			.imageUrls(doc.getImageUrls())
 			.embedding(doc.getEmbedding())
 			.build();
 
@@ -179,7 +178,7 @@ public class ProductSearchService {
 				.productCondition(doc.getProductCondition())
 				.category(doc.getCategory())
 				.sellerId(doc.getSellerId())
-				.imageUrl(doc.getImageUrl())
+				.imageUrls(doc.getImageUrls())
 				.embedding(doc.getEmbedding())
 				.startPrice(doc.getStartPrice())
 				.finalPrice(doc.getFinalPrice())

--- a/product-service/src/main/java/com/bugzero/rarego/product/domain/document/ProductSearchDocument.java
+++ b/product-service/src/main/java/com/bugzero/rarego/product/domain/document/ProductSearchDocument.java
@@ -71,8 +71,8 @@ public class ProductSearchDocument {
 	@Field(type = FieldType.Long)
 	private Long sellerId;
 
-	@Field(type = FieldType.Text)
-	private String imageUrl;
+	@Field(type = FieldType.Keyword)
+	private List<String> imageUrls;
 
 	// 상품명+설명 벡터
 	@Field(type = FieldType.Dense_Vector,

--- a/product-service/src/test/java/com/bugzero/rarego/product/app/ProductSearchServiceTest.java
+++ b/product-service/src/test/java/com/bugzero/rarego/product/app/ProductSearchServiceTest.java
@@ -83,7 +83,7 @@ class ProductSearchServiceTest {
 		assertThat(savedDoc.getProductId()).isEqualTo(productId);
 		assertThat(savedDoc.getAuctionId()).isEqualTo(auctionId);
 		assertThat(savedDoc.getAuctionStatus()).isEqualTo(AuctionStatus.SCHEDULED);
-		assertThat(savedDoc.getImageUrl()).isEqualTo("http://image.url");
+		assertThat(savedDoc.getImageUrls()).containsExactly("http://image.url");
 	}
 
 	@Test
@@ -102,7 +102,8 @@ class ProductSearchServiceTest {
 		ArgumentCaptor<ProductSearchDocument> captor = ArgumentCaptor.forClass(ProductSearchDocument.class);
 		verify(searchRepository).save(captor.capture());
 
-		assertThat(captor.getValue().getImageUrl()).isEqualTo("http://first.jpg");
+		assertThat(captor.getValue().getImageUrls())
+			.containsExactly("http://first.jpg", "http://second.jpg", "http://third.jpg");
 	}
 
 	@Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #483 

## 📝 수정 요약

⚠️private final S3Utils s3Utils 필드 추가 (@ RequiredArgsConstructor로 자동 주입)
convertToDto()에서 imageUrls 변환 시 s3Utils::getPublicUrl 적용
ES에 이미 full URL이 저장된 기존 데이터도 안전하게 처리됨.

ProductImage → buildDocument() [전체 리스트 저장] → ES → convertToDto() [S3Utils로 public URL 변환] → ProductAuctionResponseDto


 ⚠️기존 imageUrl (단일 String)의 문제:                                                          
  - ES에는 썸네일 1장만 저장 → 상품 상세 페이지에서 나머지 이미지를 보려면 별도 API 호출 필요
  - ProductAuctionResponseDto는 이미 thumbnailUrl + imageUrls 두 필드를 가지고 있었는데, ES에 1장밖에 없으니 imageUrls를 제대로 채울 수 없었음                                             

  // 기존: imageUrls가 항상 비어있거나 1장짜리
  ProductAuctionResponseDto
    .thumbnailUrl = "products/abc.jpg"
    .imageUrls    = []  // 사실상 무의미

  imageUrls (List)로 변경한 이유:
  - ProductImage는 sortOrder가 있는 별도 엔티티 → 원래부터 다중 이미지 구조
  - ES는 비정규화 저장소이므로 조인 없이 한 번에 필요한 데이터를 제공하는 게 목적에 맞음
  - ES 1회 조회로 전체 이미지 리스트까지 반환 가능

  // 변경 후: 모든 이미지 활용 가능
  ProductAuctionResponseDto
    .thumbnailUrl = "https://bucket.s3.../products/abc.jpg"  // 첫 번째 이미지
    .imageUrls    = ["https://...abc.jpg", "https://...def.jpg", ...]  // 전체

- 🚨 문제점
  - 경매 상세 조회에서 이미지를 썸네일로 지정한 이미지만 볼 수 있는 문제
  - S3 관련 메서드를 통하지 않으면 S3 서버에서 Access Denied 에러를 반환하며 이미지가 렌더링되지 않는 문제 
- 🔍 원인 분석
  - 사용자에게 필요한 사진이 썸네일 이미지라고만 생각했었음. 
  - 이미지 url 관련 규칙을 ES로 변경할 때 product와 의존성을 제거하느라 S3 관련 조회 메서드를 없애고 이미지 링크만 확인해서 저장하도록 했었음.
- 💡 해결 방법
  - 이미지를 단건만 가져오는 것에서 리스트를 가져오는 것으로 변경
  - 새로 생긴 common의 S3Utils을 통해 public url로 변환하도록 변경

## 🛠️ PR 유형
- [x] 버그 수정
- [ ] 테스트 리팩토링
- [x] 코드 리팩토링
- [ ] 문서 수정

## 💬 공유사항 및 자료 to 리뷰어 (선택)

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
10+
