### PR TITLE
[CHORE/auth] 포트번호를 8089 -> 8080으로 변경

### DIFF
--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 COPY --from=build /app/auth-service/build/libs/auth-service-*.jar app.jar
 
 # 애플리케이션 포트 노출 (docker-compose에서 설정할 포트와 맞춤)
-EXPOSE 8089
+EXPOSE 8080
 
 # 애플리케이션 실행
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8089
+  port: 8080
   forward-headers-strategy: native
   tomcat:
     relaxed-query-chars: '[,]'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
     image: ${AUTH_DOCKER_IMAGE:-rarego-auth-service:latest}
     container_name: rarego-auth-service
     ports:
-      - "8089:8089"
+      - "8080:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
       SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -14,7 +14,7 @@ server {
 
     # Auth Service
     location ~ ^/(api/v1/auth|oauth2|login/oauth2) {
-        set $auth_upstream auth-service:8089;
+        set $auth_upstream auth-service:8080;
         proxy_pass http://$auth_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -105,7 +105,7 @@ server {
 
     # Swagger / API Docs
     location ~ ^/(api-docs|swagger-ui|v3/api-docs) {
-        set $auth_upstream auth-service:8089;
+        set $auth_upstream auth-service:8080;
         proxy_pass http://$auth_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -170,7 +170,7 @@ server {
 
     # Auth Service
     location ~ ^/(api/v1/auth|oauth2|login/oauth2) {
-        set $auth_upstream auth-service:8089;
+        set $auth_upstream auth-service:8080;
         proxy_pass http://$auth_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -275,7 +275,7 @@ server {
     }
 
     location /api/v1/internal/auth {
-        set $auth_upstream auth-service:8089;
+        set $auth_upstream auth-service:8080;
         proxy_pass http://$auth_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -7,7 +7,7 @@ server {
 
     # Auth Service
     location ~ ^/(api/v1/auth|oauth2|login/oauth2) {
-        proxy_pass http://host.docker.internal:8089;
+        proxy_pass http://host.docker.internal:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -118,7 +118,7 @@ server {
     }
 
     location /api/v1/internal/auth {
-        proxy_pass http://host.docker.internal:8089;
+        proxy_pass http://host.docker.internal:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -128,7 +128,7 @@ server {
 
     # Swagger / API Docs
     location ~ ^/(api-docs|swagger-ui|v3/api-docs) {
-        proxy_pass http://host.docker.internal:8089;
+        proxy_pass http://host.docker.internal:8080;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
     }

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -8,6 +8,11 @@ scrape_configs:
     static_configs:
       - targets: ["prometheus:9090"]
 
+  - job_name: auth-service
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: [ "auth-service:8080" ]
+
   - job_name: member-service
     metrics_path: /actuator/prometheus
     static_configs:
@@ -18,22 +23,18 @@ scrape_configs:
     static_configs:
       - targets: ["payment-service:8082"]
 
-  - job_name: product-service
-    metrics_path: /actuator/prometheus
-    static_configs:
-      - targets: [ "product-service:8084" ]
-
   - job_name: auction-service
     metrics_path: /actuator/prometheus
     static_configs:
       - targets: [ "auction-service:8083" ]
 
+  - job_name: product-service
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: [ "product-service:8084" ]
+
+
   - job_name: notification-service
     metrics_path: /actuator/prometheus
     static_configs:
       - targets: [ "notification-service:8085" ]
-
-  - job_name: auth-service
-    metrics_path: /actuator/prometheus
-    static_configs:
-      - targets: [ "auth-service:8089" ]

--- a/k8s/apps/auth-service.yaml
+++ b/k8s/apps/auth-service.yaml
@@ -22,7 +22,7 @@ spec:
       - name: auth-service
         image: rarego-auth-service:latest
         ports:
-        - containerPort: 8089
+        - containerPort: 8080
         resources:
           requests:
             memory: "256Mi"
@@ -33,7 +33,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /actuator/health/liveness
-            port: 8089
+            port: 8080
           initialDelaySeconds: 180
           periodSeconds: 10
           timeoutSeconds: 3
@@ -41,7 +41,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /actuator/health/readiness
-            port: 8089
+            port: 8080
           initialDelaySeconds: 90
           periodSeconds: 5
           timeoutSeconds: 3
@@ -49,7 +49,7 @@ spec:
         startupProbe:
           httpGet:
             path: /actuator/health/readiness
-            port: 8089
+            port: 8080
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 60
@@ -125,5 +125,5 @@ spec:
     app: auth-service
   ports:
   - protocol: TCP
-    port: 8089
-    targetPort: 8089
+    port: 8080
+    targetPort: 8080

--- a/k8s/infra/internal-gateway.yaml
+++ b/k8s/infra/internal-gateway.yaml
@@ -26,7 +26,7 @@ data:
 
             # Auth Service
             location ~ ^/(api/v1/internal/auth|api/v1/auth|oauth2|login/oauth2) {
-                proxy_pass http://auth-service.rarego.svc.cluster.local:8089;
+                proxy_pass http://auth-service.rarego.svc.cluster.local:8080;
                 proxy_set_header Host $host;
             }
             # Member Service

--- a/k8s/ingress/ingress.yaml
+++ b/k8s/ingress/ingress.yaml
@@ -24,21 +24,21 @@ spec:
           service:
             name: auth-service
             port:
-              number: 8089
+              number: 8080
       - path: /oauth2
         pathType: Prefix
         backend:
           service:
             name: auth-service
             port:
-              number: 8089
+              number: 8080
       - path: /login/oauth2
         pathType: Prefix
         backend:
           service:
             name: auth-service
             port:
-              number: 8089
+              number: 8080
       # Auction Service (Specific Member activities)
       - path: /api/v1/members/me/bids
         pathType: Prefix


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #505 

## 🚀 작업 내용

8080 포트에서 docker 환경 작동 확인
<img width="1478" height="786" alt="스크린샷 2026-02-24 오후 7 22 57" src="https://github.com/user-attachments/assets/0b5fb80c-1499-4d40-b50e-68a92ac42624" />

- [x] auth-service, docker, k8s에 설정된 auth-service 어플리케이션의 포트를 8089 -> 8080으로 수정했습니다.

## 🔍 리뷰 요청 사항 및 공유자료
변경되지 않은 부분, 배포에 이상이 있는 부분이 있는지 확인 부탁드립니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션을 지켰습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다.

## 🤔 Review 예상 시간
1+