### PR TITLE
[REFACTOR/auction] 경매진행 전 시작가 수정 시 시작가 - 현재가 불일치 문제 해결

### DIFF
--- a/auction-service/src/main/java/com/bugzero/rarego/domain/Auction.java
+++ b/auction-service/src/main/java/com/bugzero/rarego/domain/Auction.java
@@ -110,6 +110,7 @@ public class Auction extends BaseIdAndTime {
 	public void update(int durationDays, int startPrice) {
 		this.durationDays = durationDays;
 		this.startPrice = startPrice;
+		this.currentPrice = startPrice;
 		this.tickSize = AuctionTickPolicy.resolveTickSize(startPrice);
 	}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
close: #이슈번호

## 🚀 작업 내용
<!-- 복잡한 기능에서는 구현 스크린샷을 첨부해주세요 -->
<!-- 특별한 기능을 추가할 때는 왜 이런 기능을, 이런 방식으로 구현했는지 설명을 자세히 적어주세요 -->
<!-- 코드에 변경사항이 있으면 작성해주세요 (ex. API 주소 추가/변경, 이벤트 추가/변경) -->

경매진행 전 경매정보에서 시작가 수정 시 시작가 - 현재가 불일치 문제 해결


